### PR TITLE
Merge upstream BucketingSink changes

### DIFF
--- a/docs/dev/connectors/filesystem_sink.md
+++ b/docs/dev/connectors/filesystem_sink.md
@@ -89,8 +89,13 @@ and write them to part files, separated by newline. To specify a custom writer u
 on a `BucketingSink`. If you want to write Hadoop SequenceFiles you can use the provided
 `SequenceFileWriter` which can also be configured to use compression.
 
-The last configuration option is the batch size. This specifies when a part file should be closed
-and a new one started. (The default part file size is 384 MB).
+There are two configuration options that specify when a part file should be closed
+and a new one started:
+ 
+* By setting a batch size (The default part file size is 384 MB)
+* By setting a batch roll over time interval (The default roll over interval is `Long.MAX_VALUE`)
+
+A new part file is started when either of these two conditions is satisfied.
 
 Example:
 
@@ -103,6 +108,7 @@ BucketingSink<String> sink = new BucketingSink<String>("/base/path");
 sink.setBucketer(new DateTimeBucketer<String>("yyyy-MM-dd--HHmm"));
 sink.setWriter(new SequenceFileWriter<IntWritable, Text>());
 sink.setBatchSize(1024 * 1024 * 400); // this is 400 MB,
+sink.setBatchRolloverInterval(20 * 60 * 1000); // this is 20 mins
 
 input.addSink(sink);
 
@@ -116,6 +122,7 @@ val sink = new BucketingSink[String]("/base/path")
 sink.setBucketer(new DateTimeBucketer[String]("yyyy-MM-dd--HHmm"))
 sink.setWriter(new SequenceFileWriter[IntWritable, Text]())
 sink.setBatchSize(1024 * 1024 * 400) // this is 400 MB,
+sink.setBatchRolloverInterval(20 * 60 * 1000); // this is 20 mins
 
 input.addSink(sink)
 
@@ -130,8 +137,8 @@ This will create a sink that writes to bucket files that follow this schema:
 ```
 
 Where `date-time` is the string that we get from the date/time format, `parallel-task` is the index
-of the parallel sink instance and `count` is the running number of part files that where created
-because of the batch size.
+of the parallel sink instance and `count` is the running number of part files that were created
+because of the batch size or batch roll over interval.
 
 For in-depth information, please refer to the JavaDoc for
 [BucketingSink](http://flink.apache.org/docs/latest/api/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.html).

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/RollingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/RollingSink.java
@@ -699,9 +699,9 @@ public class RollingSink<T> extends RichSinkFunction<T>
 					}
 
 				} else {
-					LOG.debug("Writing valid-length file for {} to specify valid length {}", partPath, bucketState.currentFileValidLength);
 					Path validLengthFilePath = getValidLengthPathFor(partPath);
 					if (!fs.exists(validLengthFilePath) && fs.exists(partPath)) {
+						LOG.debug("Writing valid-length file for {} to specify valid length {}", partPath, bucketState.currentFileValidLength);
 						FSDataOutputStream lengthFileOut = fs.create(validLengthFilePath);
 						lengthFileOut.writeUTF(Long.toString(bucketState.currentFileValidLength));
 						lengthFileOut.close();

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -226,7 +226,12 @@ public class BucketingSink<T>
 	/**
 	 * The default prefix for part files.
 	 */
-	private static final String DEFAULT_PART_REFIX = "part";
+	private static final String DEFAULT_PART_PREFIX = "part";
+
+	/**
+	 * The default suffix for part files.
+	 */
+	private static final String DEFAULT_PART_SUFFIX = null;
 
 	/**
 	 * The default timeout for asynchronous operations such as recoverLease and truncate (in {@code ms}).
@@ -263,7 +268,8 @@ public class BucketingSink<T>
 	private String validLengthSuffix = DEFAULT_VALID_SUFFIX;
 	private String validLengthPrefix = DEFAULT_VALID_PREFIX;
 
-	private String partPrefix = DEFAULT_PART_REFIX;
+	private String partPrefix = DEFAULT_PART_PREFIX;
+	private String partSuffix = DEFAULT_PART_SUFFIX;
 
 	private boolean useTruncate = true;
 
@@ -528,6 +534,10 @@ public class BucketingSink<T>
 				fs.exists(getInProgressPathFor(partPath))) {
 			bucketState.partCounter++;
 			partPath = new Path(bucketPath, partPrefix + "-" + subtaskIndex + "-" + bucketState.partCounter);
+		}
+
+		if (partSuffix != null) {
+			partPath = partPath.suffix(partSuffix);
 		}
 
 		// increase, so we don't have to check for this name next time
@@ -983,6 +993,14 @@ public class BucketingSink<T>
 	 */
 	public BucketingSink<T> setValidLengthPrefix(String validLengthPrefix) {
 		this.validLengthPrefix = validLengthPrefix;
+		return this;
+	}
+
+	/**
+	 * Sets the prefix of part files.  The default is no suffix.
+	 */
+	public BucketingSink<T> setPartSuffix(String partSuffix) {
+		this.partSuffix = partSuffix;
 		return this;
 	}
 

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -550,6 +550,12 @@ public class BucketingSink<T>
 		Path inProgressPath = getInProgressPathFor(partPath);
 		if (bucketState.writer == null) {
 			bucketState.writer = writerTemplate.duplicate();
+			if (bucketState.writer == null) {
+				throw new UnsupportedOperationException(
+					"Could not duplicate writer. " +
+						"Class '" + writerTemplate.getClass().getCanonicalName() + "' must implement the 'Writer.duplicate()' method."
+				);
+			}
 		}
 
 		bucketState.writer.open(fs, inProgressPath);

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -88,9 +88,11 @@ import java.util.UUID;
  * and a rolling counter. For example the file {@code "part-1-17"} contains the data from
  * {@code subtask 1} of the sink and is the {@code 17th} bucket created by that subtask. Per default
  * the part prefix is {@code "part"} but this can be configured using {@link #setPartPrefix(String)}.
- * When a part file becomes bigger than the user-specified batch size the current part file is closed,
- * the part counter is increased and a new part file is created. The batch size defaults to {@code 384MB},
- * this can be configured using {@link #setBatchSize(long)}.
+ * When a part file becomes bigger than the user-specified batch size or when the part file becomes older
+ * than the user-specified roll over interval the current part file is closed, the part counter is increased
+ * and a new part file is created. The batch size defaults to {@code 384MB}, this can be configured
+ * using {@link #setBatchSize(long)}. The roll over interval defaults to {@code Long.MAX_VALUE} and
+ * this can be configured using {@link #setBatchRolloverInterval(long)}.
  *
  *
  * <p>In some scenarios, the open buckets are required to change based on time. In these cases, the sink
@@ -136,6 +138,10 @@ import java.util.UUID;
  *         every element, separated by newlines. You can configure the writer using the
  *         {@link #setWriter(Writer)}. For example, {@link SequenceFileWriter}
  *         can be used to write Hadoop {@code SequenceFiles}.
+ *     </li>
+ *     <li>
+ *       	{@link #closePartFilesByTime(long)} closes buckets that have not been written to for
+ *       	{@code inactiveBucketThreshold} or if they are older than {@code batchRolloverInterval}.
  *     </li>
  * </ol>
  *
@@ -240,6 +246,11 @@ public class BucketingSink<T>
 	private static final long DEFAULT_ASYNC_TIMEOUT_MS = 60 * 1000;
 
 	/**
+	 * The default time interval at which part files are written to the filesystem.
+	 */
+	private static final long DEFAULT_BATCH_ROLLOVER_INTERVAL = Long.MAX_VALUE;
+
+	/**
 	 * The base {@code Path} that stores all bucket directories.
 	 */
 	private final String basePath;
@@ -258,6 +269,7 @@ public class BucketingSink<T>
 	private long batchSize = DEFAULT_BATCH_SIZE;
 	private long inactiveBucketCheckInterval = DEFAULT_INACTIVE_BUCKET_CHECK_INTERVAL_MS;
 	private long inactiveBucketThreshold = DEFAULT_INACTIVE_BUCKET_THRESHOLD_MS;
+	private long batchRolloverInterval = DEFAULT_BATCH_ROLLOVER_INTERVAL;
 
 	// These are the actually configured prefixes/suffixes
 	private String inProgressSuffix = DEFAULT_IN_PROGRESS_SUFFIX;
@@ -442,7 +454,7 @@ public class BucketingSink<T>
 			state.addBucketState(bucketPath, bucketState);
 		}
 
-		if (shouldRoll(bucketState)) {
+		if (shouldRoll(bucketState, currentProcessingTime)) {
 			openNewPartFile(bucketPath, bucketState);
 		}
 
@@ -456,9 +468,10 @@ public class BucketingSink<T>
 	 * <ol>
 	 *     <li>no file is created yet for the task to write to, or</li>
 	 *     <li>the current file has reached the maximum bucket size.</li>
+	 *     <li>the current file is older than roll over interval</li>
 	 * </ol>
 	 */
-	private boolean shouldRoll(BucketState<T> bucketState) throws IOException {
+	private boolean shouldRoll(BucketState<T> bucketState, long currentProcessingTime) throws IOException {
 		boolean shouldRoll = false;
 		int subtaskIndex = getRuntimeContext().getIndexOfThisSubtask();
 		if (!bucketState.isWriterOpen) {
@@ -473,6 +486,14 @@ public class BucketingSink<T>
 					subtaskIndex,
 					writePosition,
 					batchSize);
+			} else {
+				if (currentProcessingTime - bucketState.creationTime > batchRolloverInterval) {
+					shouldRoll = true;
+					LOG.debug(
+						"BucketingSink {} starting new bucket because file is older than roll over interval {}.",
+						subtaskIndex,
+						batchRolloverInterval);
+				}
 			}
 		}
 		return shouldRoll;
@@ -482,21 +503,23 @@ public class BucketingSink<T>
 	public void onProcessingTime(long timestamp) throws Exception {
 		long currentProcessingTime = processingTimeService.getCurrentProcessingTime();
 
-		checkForInactiveBuckets(currentProcessingTime);
+		closePartFilesByTime(currentProcessingTime);
 
 		processingTimeService.registerTimer(currentProcessingTime + inactiveBucketCheckInterval, this);
 	}
 
 	/**
 	 * Checks for inactive buckets, and closes them. Buckets are considered inactive if they have not been
-	 * written to for a period greater than {@code inactiveBucketThreshold} ms. This enables in-progress
-	 * files to be moved to the pending state and be finalised on the next checkpoint.
+	 * written to for a period greater than {@code inactiveBucketThreshold} ms. Buckets are also closed if they are
+	 * older than {@code batchRolloverInterval} ms. This enables in-progress files to be moved to the pending state
+	 * and be finalised on the next checkpoint.
 	 */
-	private void checkForInactiveBuckets(long currentProcessingTime) throws Exception {
+	private void closePartFilesByTime(long currentProcessingTime) throws Exception {
 
 		synchronized (state.bucketStates) {
 			for (Map.Entry<String, BucketState<T>> entry : state.bucketStates.entrySet()) {
-				if (entry.getValue().lastWrittenToTime < currentProcessingTime - inactiveBucketThreshold) {
+				if ((entry.getValue().lastWrittenToTime < currentProcessingTime - inactiveBucketThreshold)
+						|| (entry.getValue().creationTime < currentProcessingTime - batchRolloverInterval)) {
 					LOG.debug("BucketingSink {} closing bucket due to inactivity of over {} ms.",
 						getRuntimeContext().getIndexOfThisSubtask(), inactiveBucketThreshold);
 					closeCurrentPartFile(entry.getValue());
@@ -536,6 +559,9 @@ public class BucketingSink<T>
 			bucketState.partCounter++;
 			partPath = new Path(bucketPath, partPrefix + "-" + subtaskIndex + "-" + bucketState.partCounter);
 		}
+
+		// Record the creation time of the bucket
+		bucketState.creationTime = processingTimeService.getCurrentProcessingTime();
 
 		if (partSuffix != null) {
 			partPath = partPath.suffix(partSuffix);
@@ -915,6 +941,25 @@ public class BucketingSink<T>
 	}
 
 	/**
+	 * Sets the roll over interval in milliseconds.
+	 *
+	 *
+	 * <p>When a bucket part file is older than the roll over interval, a new bucket part file is
+	 * started and the old one is closed. The name of the bucket file depends on the {@link Bucketer}.
+	 * Additionally, the old part file is also closed if the bucket is not written to for a minimum of
+	 * {@code inactiveBucketThreshold} ms.
+	 *
+	 * @param batchRolloverInterval The roll over interval in milliseconds
+	 */
+	public BucketingSink<T> setBatchRolloverInterval(long batchRolloverInterval) {
+		if (batchRolloverInterval > 0) {
+			this.batchRolloverInterval = batchRolloverInterval;
+		}
+
+		return this;
+	}
+
+	/**
 	 * Sets the default time between checks for inactive buckets.
 	 *
 	 * @param interval The timeout, in milliseconds.
@@ -927,6 +972,8 @@ public class BucketingSink<T>
 	/**
 	 * Sets the default threshold for marking a bucket as inactive and closing its part files.
 	 * Buckets which haven't been written to for at least this period of time become inactive.
+	 * Additionally, part files for the bucket are also closed if the bucket is older than
+	 * {@code batchRolloverInterval} ms.
 	 *
 	 * @param threshold The timeout, in milliseconds.
 	 */
@@ -1115,6 +1162,11 @@ public class BucketingSink<T>
 		 * The time this bucket was last written to.
 		 */
 		long lastWrittenToTime;
+
+		/**
+		 * The time this bucket was created.
+		 */
+		long creationTime;
 
 		/**
 		 * Pending files that accumulated since the last checkpoint.

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkFaultToleranceITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkFaultToleranceITCase.java
@@ -51,6 +51,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.IN_PROGRESS_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PENDING_SUFFIX;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -74,9 +76,6 @@ public class RollingSinkFaultToleranceITCase extends StreamFaultToleranceTestBas
 	private static org.apache.hadoop.fs.FileSystem dfs;
 
 	private static String outPath;
-
-	private static final String PENDING_SUFFIX = ".pending";
-	private static final String IN_PROGRESS_SUFFIX = ".in-progress";
 
 	@BeforeClass
 	public static void createHDFS() throws IOException {

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkFaultToleranceITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkFaultToleranceITCase.java
@@ -51,6 +51,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.IN_PROGRESS_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PENDING_SUFFIX;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -71,9 +73,6 @@ public class BucketingSinkFaultToleranceITCase extends StreamFaultToleranceTestB
 	private static org.apache.hadoop.fs.FileSystem dfs;
 
 	private static String outPath;
-
-	private static final String PENDING_SUFFIX = ".pending";
-	private static final String IN_PROGRESS_SUFFIX = ".in-progress";
 
 	@BeforeClass
 	public static void createHDFS() throws IOException {

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkMigrationTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkMigrationTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.streaming.util.migration.MigrationTestUtil;
 import org.apache.flink.streaming.util.migration.MigrationVersion;
 import org.apache.flink.util.OperatingSystem;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -45,12 +44,16 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.IN_PROGRESS_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PART_PREFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PENDING_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.VALID_LENGTH_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.checkLocalFs;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -71,11 +74,6 @@ public class BucketingSinkMigrationTest {
 
 	@ClassRule
 	public static TemporaryFolder tempFolder = new TemporaryFolder();
-
-	private static final String PART_PREFIX = "part";
-	private static final String PENDING_SUFFIX = ".pending";
-	private static final String IN_PROGRESS_SUFFIX = ".in-progress";
-	private static final String VALID_LENGTH_SUFFIX = ".valid";
 
 	@BeforeClass
 	public static void verifyOS() {
@@ -127,13 +125,13 @@ public class BucketingSinkMigrationTest {
 		testHarness.processElement(new StreamRecord<>("test1", 0L));
 		testHarness.processElement(new StreamRecord<>("test2", 0L));
 
-		checkFs(outDir, 1, 1, 0, 0);
+		checkLocalFs(outDir, 1, 1, 0, 0);
 
 		testHarness.processElement(new StreamRecord<>("test3", 0L));
 		testHarness.processElement(new StreamRecord<>("test4", 0L));
 		testHarness.processElement(new StreamRecord<>("test5", 0L));
 
-		checkFs(outDir, 1, 4, 0, 0);
+		checkLocalFs(outDir, 1, 4, 0, 0);
 
 		OperatorStateHandles snapshot = testHarness.snapshot(0L, 0L);
 
@@ -155,7 +153,8 @@ public class BucketingSinkMigrationTest {
 			.setValidLengthPrefix("")
 			.setInProgressSuffix(IN_PROGRESS_SUFFIX)
 			.setPendingSuffix(PENDING_SUFFIX)
-			.setValidLengthSuffix(VALID_LENGTH_SUFFIX);
+			.setValidLengthSuffix(VALID_LENGTH_SUFFIX)
+			.setUseTruncate(false); // don't use truncate because files do not exist
 
 		OneInputStreamOperatorTestHarness<String, Object> testHarness = new OneInputStreamOperatorTestHarness<>(
 			new StreamSink<>(sink), 10, 1, 0);
@@ -174,37 +173,9 @@ public class BucketingSinkMigrationTest {
 		testHarness.processElement(new StreamRecord<>("test1", 0L));
 		testHarness.processElement(new StreamRecord<>("test2", 0L));
 
-		checkFs(outDir, 1, 1, 0, 0);
+		checkLocalFs(outDir, 1, 1, 0, 0);
 
 		testHarness.close();
-	}
-
-	private void checkFs(File outDir, int inprogress, int pending, int completed, int valid) throws IOException {
-		int inProg = 0;
-		int pend = 0;
-		int compl = 0;
-		int val = 0;
-
-		for (File file: FileUtils.listFiles(outDir, null, true)) {
-			if (file.getAbsolutePath().endsWith("crc")) {
-				continue;
-			}
-			String path = file.getPath();
-			if (path.endsWith(IN_PROGRESS_SUFFIX)) {
-				inProg++;
-			} else if (path.endsWith(PENDING_SUFFIX)) {
-				pend++;
-			} else if (path.endsWith(VALID_LENGTH_SUFFIX)) {
-				val++;
-			} else if (path.contains(PART_PREFIX)) {
-				compl++;
-			}
-		}
-
-		Assert.assertEquals(inprogress, inProg);
-		Assert.assertEquals(pending, pend);
-		Assert.assertEquals(completed, compl);
-		Assert.assertEquals(valid, val);
 	}
 
 	static class ValidatingBucketingSink<T> extends BucketingSink<T> {

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
@@ -67,6 +67,12 @@ import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.IN_PROGRESS_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PART_PREFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PENDING_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.VALID_LENGTH_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.checkLocalFs;
+
 /**
  * Tests for the {@link BucketingSink}.
  */
@@ -77,11 +83,6 @@ public class BucketingSinkTest {
 	private static MiniDFSCluster hdfsCluster;
 	private static org.apache.hadoop.fs.FileSystem dfs;
 	private static String hdfsURI;
-
-	private static final String PART_PREFIX = "part";
-	private static final String PENDING_SUFFIX = ".pending";
-	private static final String IN_PROGRESS_SUFFIX = ".in-progress";
-	private static final String VALID_LENGTH_SUFFIX = ".valid";
 
 	private OneInputStreamOperatorTestHarness<String, Object> createRescalingTestSink(
 		File outDir, int totalParallelism, int taskIdx, long inactivityInterval) throws Exception {
@@ -186,13 +187,13 @@ public class BucketingSinkTest {
 
 		testHarness.processElement(new StreamRecord<>("test1", 1L));
 		testHarness.processElement(new StreamRecord<>("test2", 1L));
-		checkFs(outDir, 2, 0 , 0, 0);
+		checkLocalFs(outDir, 2, 0 , 0, 0);
 
 		testHarness.setProcessingTime(101L);	// put some in pending
-		checkFs(outDir, 0, 2, 0, 0);
+		checkLocalFs(outDir, 0, 2, 0, 0);
 
 		testHarness.snapshot(0, 0);				// put them in pending for 0
-		checkFs(outDir, 0, 2, 0, 0);
+		checkLocalFs(outDir, 0, 2, 0, 0);
 
 		testHarness.processElement(new StreamRecord<>("test3", 1L));
 		testHarness.processElement(new StreamRecord<>("test4", 1L));
@@ -200,13 +201,13 @@ public class BucketingSinkTest {
 		testHarness.setProcessingTime(202L);	// put some in pending
 
 		testHarness.snapshot(1, 0);				// put them in pending for 1
-		checkFs(outDir, 0, 4, 0, 0);
+		checkLocalFs(outDir, 0, 4, 0, 0);
 
 		testHarness.notifyOfCompletedCheckpoint(0);	// put the pending for 0 to the "committed" state
-		checkFs(outDir, 0, 2, 2, 0);
+		checkLocalFs(outDir, 0, 2, 2, 0);
 
 		testHarness.notifyOfCompletedCheckpoint(1); // put the pending for 1 to the "committed" state
-		checkFs(outDir, 0, 0, 4, 0);
+		checkLocalFs(outDir, 0, 0, 4, 0);
 	}
 
 	@Test
@@ -221,36 +222,36 @@ public class BucketingSinkTest {
 
 		testHarness.processElement(new StreamRecord<>("test1", 1L));
 		testHarness.processElement(new StreamRecord<>("test2", 1L));
-		checkFs(outDir, 2, 0 , 0, 0);
+		checkLocalFs(outDir, 2, 0 , 0, 0);
 
 		// this is to check the inactivity threshold
 		testHarness.setProcessingTime(101L);
-		checkFs(outDir, 0, 2, 0, 0);
+		checkLocalFs(outDir, 0, 2, 0, 0);
 
 		testHarness.processElement(new StreamRecord<>("test3", 1L));
-		checkFs(outDir, 1, 2, 0, 0);
+		checkLocalFs(outDir, 1, 2, 0, 0);
 
 		testHarness.snapshot(0, 0);
-		checkFs(outDir, 1, 2, 0, 0);
+		checkLocalFs(outDir, 1, 2, 0, 0);
 
 		testHarness.notifyOfCompletedCheckpoint(0);
-		checkFs(outDir, 1, 0, 2, 0);
+		checkLocalFs(outDir, 1, 0, 2, 0);
 
 		OperatorStateHandles snapshot = testHarness.snapshot(1, 0);
 
 		testHarness.close();
-		checkFs(outDir, 0, 1, 2, 0);
+		checkLocalFs(outDir, 0, 1, 2, 0);
 
 		testHarness = createRescalingTestSink(outDir, 1, 0, 100);
 		testHarness.setup();
 		testHarness.initializeState(snapshot);
 		testHarness.open();
-		checkFs(outDir, 0, 0, 3, 1);
+		checkLocalFs(outDir, 0, 0, 3, 1);
 
 		snapshot = testHarness.snapshot(2, 0);
 
 		testHarness.processElement(new StreamRecord<>("test4", 10));
-		checkFs(outDir, 1, 0, 3, 1);
+		checkLocalFs(outDir, 1, 0, 3, 1);
 
 		testHarness = createRescalingTestSink(outDir, 1, 0, 100);
 		testHarness.setup();
@@ -258,13 +259,13 @@ public class BucketingSinkTest {
 		testHarness.open();
 
 		// the in-progress file remains as we do not clean up now
-		checkFs(outDir, 1, 0, 3, 1);
+		checkLocalFs(outDir, 1, 0, 3, 1);
 
 		testHarness.close();
 
 		// at close it is not moved to final because it is not part
 		// of the current task's state, it was just a not cleaned up leftover.
-		checkFs(outDir, 1, 0, 3, 1);
+		checkLocalFs(outDir, 1, 0, 3, 1);
 	}
 
 	@Test
@@ -280,10 +281,10 @@ public class BucketingSinkTest {
 		testHarness2.open();
 
 		testHarness1.processElement(new StreamRecord<>("test1", 0L));
-		checkFs(outDir, 1, 0, 0, 0);
+		checkLocalFs(outDir, 1, 0, 0, 0);
 
 		testHarness2.processElement(new StreamRecord<>("test2", 0L));
-		checkFs(outDir, 2, 0, 0, 0);
+		checkLocalFs(outDir, 2, 0, 0, 0);
 
 		// intentionally we snapshot them in the reverse order so that the states are shuffled
 		OperatorStateHandles mergedSnapshot = AbstractStreamOperatorTestHarness.repackageState(
@@ -291,11 +292,11 @@ public class BucketingSinkTest {
 			testHarness1.snapshot(0, 0)
 		);
 
-		checkFs(outDir, 2, 0, 0, 0);
+		checkLocalFs(outDir, 2, 0, 0, 0);
 
 		// this will not be included in any checkpoint so it can be cleaned up (although we do not)
 		testHarness2.processElement(new StreamRecord<>("test3", 0L));
-		checkFs(outDir, 3, 0, 0, 0);
+		checkLocalFs(outDir, 3, 0, 0, 0);
 
 		testHarness1 = createRescalingTestSink(outDir, 2, 0, 100);
 		testHarness1.setup();
@@ -304,20 +305,20 @@ public class BucketingSinkTest {
 
 		// the one in-progress will be the one assigned to the next instance,
 		// the other is the test3 which is just not cleaned up
-		checkFs(outDir, 2, 0, 1, 1);
+		checkLocalFs(outDir, 2, 0, 1, 1);
 
 		testHarness2 = createRescalingTestSink(outDir, 2, 1, 100);
 		testHarness2.setup();
 		testHarness2.initializeState(mergedSnapshot);
 		testHarness2.open();
 
-		checkFs(outDir, 1, 0, 2, 2);
+		checkLocalFs(outDir, 1, 0, 2, 2);
 
 		testHarness1.close();
 		testHarness2.close();
 
 		// the 1 in-progress can be discarded.
-		checkFs(outDir, 1, 0, 2, 2);
+		checkLocalFs(outDir, 1, 0, 2, 2);
 	}
 
 	@Test
@@ -337,14 +338,14 @@ public class BucketingSinkTest {
 		testHarness3.open();
 
 		testHarness1.processElement(new StreamRecord<>("test1", 0L));
-		checkFs(outDir, 1, 0, 0, 0);
+		checkLocalFs(outDir, 1, 0, 0, 0);
 
 		testHarness2.processElement(new StreamRecord<>("test2", 0L));
-		checkFs(outDir, 2, 0, 0, 0);
+		checkLocalFs(outDir, 2, 0, 0, 0);
 
 		testHarness3.processElement(new StreamRecord<>("test3", 0L));
 		testHarness3.processElement(new StreamRecord<>("test4", 0L));
-		checkFs(outDir, 4, 0, 0, 0);
+		checkLocalFs(outDir, 4, 0, 0, 0);
 
 		// intentionally we snapshot them in the reverse order so that the states are shuffled
 		OperatorStateHandles mergedSnapshot = AbstractStreamOperatorTestHarness.repackageState(
@@ -358,14 +359,14 @@ public class BucketingSinkTest {
 		testHarness1.initializeState(mergedSnapshot);
 		testHarness1.open();
 
-		checkFs(outDir, 1, 0, 3, 3);
+		checkLocalFs(outDir, 1, 0, 3, 3);
 
 		testHarness2 = createRescalingTestSink(outDir, 2, 1, 100);
 		testHarness2.setup();
 		testHarness2.initializeState(mergedSnapshot);
 		testHarness2.open();
 
-		checkFs(outDir, 0, 0, 4, 4);
+		checkLocalFs(outDir, 0, 0, 4, 4);
 	}
 
 	@Test
@@ -383,13 +384,13 @@ public class BucketingSinkTest {
 		testHarness1.processElement(new StreamRecord<>("test1", 1L));
 		testHarness1.processElement(new StreamRecord<>("test2", 1L));
 
-		checkFs(outDir, 2, 0, 0, 0);
+		checkLocalFs(outDir, 2, 0, 0, 0);
 
 		testHarness2.processElement(new StreamRecord<>("test3", 1L));
 		testHarness2.processElement(new StreamRecord<>("test4", 1L));
 		testHarness2.processElement(new StreamRecord<>("test5", 1L));
 
-		checkFs(outDir, 5, 0, 0, 0);
+		checkLocalFs(outDir, 5, 0, 0, 0);
 
 		// intentionally we snapshot them in the reverse order so that the states are shuffled
 		OperatorStateHandles mergedSnapshot = AbstractStreamOperatorTestHarness.repackageState(
@@ -402,27 +403,27 @@ public class BucketingSinkTest {
 		testHarness1.initializeState(mergedSnapshot);
 		testHarness1.open();
 
-		checkFs(outDir, 2, 0, 3, 3);
+		checkLocalFs(outDir, 2, 0, 3, 3);
 
 		testHarness2 = createRescalingTestSink(outDir, 3, 1, 100);
 		testHarness2.setup();
 		testHarness2.initializeState(mergedSnapshot);
 		testHarness2.open();
 
-		checkFs(outDir, 0, 0, 5, 5);
+		checkLocalFs(outDir, 0, 0, 5, 5);
 
 		OneInputStreamOperatorTestHarness<String, Object> testHarness3 = createRescalingTestSink(outDir, 3, 2, 100);
 		testHarness3.setup();
 		testHarness3.initializeState(mergedSnapshot);
 		testHarness3.open();
 
-		checkFs(outDir, 0, 0, 5, 5);
+		checkLocalFs(outDir, 0, 0, 5, 5);
 
 		testHarness1.processElement(new StreamRecord<>("test6", 0));
 		testHarness2.processElement(new StreamRecord<>("test6", 0));
 		testHarness3.processElement(new StreamRecord<>("test6", 0));
 
-		checkFs(outDir, 3, 0, 5, 5);
+		checkLocalFs(outDir, 3, 0, 5, 5);
 
 		testHarness1.snapshot(1, 0);
 		testHarness2.snapshot(1, 0);
@@ -432,35 +433,7 @@ public class BucketingSinkTest {
 		testHarness2.close();
 		testHarness3.close();
 
-		checkFs(outDir, 0, 3, 5, 5);
-	}
-
-	private void checkFs(File outDir, int inprogress, int pending, int completed, int valid) throws IOException {
-		int inProg = 0;
-		int pend = 0;
-		int compl = 0;
-		int val = 0;
-
-		for (File file: FileUtils.listFiles(outDir, null, true)) {
-			if (file.getAbsolutePath().endsWith("crc")) {
-				continue;
-			}
-			String path = file.getPath();
-			if (path.endsWith(IN_PROGRESS_SUFFIX)) {
-				inProg++;
-			} else if (path.endsWith(PENDING_SUFFIX)) {
-				pend++;
-			} else if (path.endsWith(VALID_LENGTH_SUFFIX)) {
-				val++;
-			} else if (path.contains(PART_PREFIX)) {
-				compl++;
-			}
-		}
-
-		Assert.assertEquals(inprogress, inProg);
-		Assert.assertEquals(pending, pend);
-		Assert.assertEquals(completed, compl);
-		Assert.assertEquals(valid, val);
+		checkLocalFs(outDir, 0, 3, 5, 5);
 	}
 
 	/**

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
@@ -136,6 +136,33 @@ public class BucketingSinkTest {
 		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), 10, totalParallelism, taskIdx);
 	}
 
+	private OneInputStreamOperatorTestHarness<String, Object> createRescalingTestSinkWithRollover(
+		File outDir, int totalParallelism, int taskIdx, long inactivityInterval, long rolloverInterval) throws Exception {
+
+		BucketingSink<String> sink = new BucketingSink<String>(outDir.getAbsolutePath())
+			.setBucketer(new Bucketer<String>() {
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public Path getBucketPath(Clock clock, Path basePath, String element) {
+					return new Path(basePath, element);
+				}
+			})
+			.setWriter(new StringWriter<String>())
+			.setInactiveBucketCheckInterval(inactivityInterval)
+			.setInactiveBucketThreshold(inactivityInterval)
+			.setPartPrefix(PART_PREFIX)
+			.setInProgressPrefix("")
+			.setPendingPrefix("")
+			.setValidLengthPrefix("")
+			.setInProgressSuffix(IN_PROGRESS_SUFFIX)
+			.setPendingSuffix(PENDING_SUFFIX)
+			.setValidLengthSuffix(VALID_LENGTH_SUFFIX)
+			.setBatchRolloverInterval(rolloverInterval);
+
+		return createTestSink(sink, totalParallelism, taskIdx);
+	}
+
 	@BeforeClass
 	public static void createHDFS() throws IOException {
 		Assume.assumeTrue("HDFS cluster cannot be started on Windows without extensions.", !OperatingSystem.isWindows());
@@ -434,6 +461,40 @@ public class BucketingSinkTest {
 		testHarness3.close();
 
 		checkLocalFs(outDir, 0, 3, 5, 5);
+	}
+
+	@Test
+	public void testRolloverInterval() throws Exception {
+		final File outDir = tempFolder.newFolder();
+
+		OneInputStreamOperatorTestHarness<String, Object> testHarness = createRescalingTestSinkWithRollover(outDir, 1, 0, 1000L, 100L);
+		testHarness.setup();
+		testHarness.open();
+
+		testHarness.setProcessingTime(0L);
+
+		testHarness.processElement(new StreamRecord<>("test1", 1L));
+		checkLocalFs(outDir, 1, 0, 0, 0);
+
+		// invoke rollover based on rollover interval
+		testHarness.setProcessingTime(101L);
+		testHarness.processElement(new StreamRecord<>("test1", 2L));
+		checkLocalFs(outDir, 1, 1, 0, 0);
+
+		testHarness.snapshot(0, 0);
+		testHarness.notifyOfCompletedCheckpoint(0);
+		checkLocalFs(outDir, 1, 0, 1, 0);
+
+		// move the in-progress file to pending
+		testHarness.setProcessingTime(3000L);
+		testHarness.snapshot(1, 1);
+		checkLocalFs(outDir, 0, 1, 1, 0);
+
+		// move the pending file to "committed"
+		testHarness.notifyOfCompletedCheckpoint(1);
+		testHarness.close();
+
+		checkLocalFs(outDir, 0, 0, 2, 0);
 	}
 
 	/**

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTestUtils.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTestUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.fs.bucketing;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.junit.Assert;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+/**
+ * Test utilities for bucketing sinks.
+ */
+public class BucketingSinkTestUtils {
+
+	public static final String PART_PREFIX = "part";
+	public static final String PENDING_SUFFIX = ".pending";
+	public static final String IN_PROGRESS_SUFFIX = ".in-progress";
+	public static final String VALID_LENGTH_SUFFIX = ".valid";
+
+	/**
+	 * Verifies the correct number of written files and reasonable length files.
+	 */
+	public static void checkLocalFs(File outDir, int inprogress, int pending, int completed, int valid) throws IOException {
+		int inProg = 0;
+		int pend = 0;
+		int compl = 0;
+		int val = 0;
+
+		for (File file: FileUtils.listFiles(outDir, null, true)) {
+			if (file.getAbsolutePath().endsWith("crc")) {
+				continue;
+			}
+			String path = file.getPath();
+			if (path.endsWith(IN_PROGRESS_SUFFIX)) {
+				inProg++;
+			} else if (path.endsWith(PENDING_SUFFIX)) {
+				pend++;
+			} else if (path.endsWith(VALID_LENGTH_SUFFIX)) {
+				// check that content of length file is valid
+				try (DataInputStream dis = new DataInputStream(new FileInputStream(file))) {
+					final long validLength = Long.valueOf(dis.readUTF());
+					final String truncated = path.substring(0, path.length() - VALID_LENGTH_SUFFIX.length());
+					Assert.assertTrue("Mismatch between valid length and file size.",
+						FileUtils.sizeOf(new File(truncated)) >= validLength);
+				}
+				val++;
+			} else if (path.contains(PART_PREFIX)) {
+				compl++;
+			}
+		}
+
+		Assert.assertEquals(inprogress, inProg);
+		Assert.assertEquals(pending, pend);
+		Assert.assertEquals(completed, compl);
+		// check length file in case truncating is not supported
+		try {
+			RawLocalFileSystem.class.getMethod("truncate", Path.class, long.class);
+		} catch (NoSuchMethodException e) {
+			Assert.assertEquals(valid, val);
+		}
+	}
+}


### PR DESCRIPTION
This PR cherry-picks the following upstream commits from apache/flink -
```Author: Lakshmi Gururaja Rao <glaksh100@gmail.com>
Date:   Mon Apr 16 16:31:49 2018 -0700

    [FLINK-9138] [bucketSink] Support time-based rollover of part files in BucketingSink.

    This closes #5860.

commit 23d9c6cc33e8e4c76a058ede4e142c45f443d21d
Author: Pavel Shvetsov <pavel_shvetsov@epam.com>
Date:   Fri Apr 27 10:28:58 2018 +0300

    [FLINK-8237] [bucketSink] BucketingSink returns error message if Writer.duplicate returns null.

    This closes #5927.

commit 284aba3c8f1b854df1b2e35dde0a7dddf9122b0d
Author: Timo Walther <twalthr@apache.org>
Date:   Tue Apr 17 15:12:55 2018 +0200

    [FLINK-9113] [connectors] Use raw local file system for bucketing sink to prevent data loss

    This change replaces Hadoop's LocalFileSystem (which is a checksumming filesystem) with the RawFileSystem implementation. For performing checksums the default filesystem only flushes in 512 byte intervals which might lead to data loss during checkpointing. In order to guarantee exact results we skip the checksum computation and perform a raw flush.

    Negative effect: Existing checksums are not maintained anymore and thus become invalid.

    This closes #5861.

commit f8baa96f81c34cd324c3bdc7bda3c28ec9aea7e1
Author: Jelmer Kuperus <jkuperus@marktplaats.nl>
Date:   Wed Feb 28 21:34:08 2018 +0100

    [FLINK-8814] [file system sinks] Control over the extension of part files created by BucketingSink.

commit 6c6639fc4540c93e0f8c824a7f09737010a78509
Author: Aljoscha Krettek <aljoscha.krettek@gmail.com>
Date:   Wed Feb 14 14:48:22 2018 +0100

    [FLINK-8600] Allow disabling truncate() check in BucketingSink

    The test was failing when using PrestoS3FileSystem because it doesn't
    use an absolute/qualified path.
```