### PR TITLE
[FLINK-9692][Kinesis Connector] Fix bug in adaptive reads implementation

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -55,7 +55,7 @@ public class ShardConsumer<T> implements Runnable {
 
 	// AWS Kinesis has a read limit of 2 Mb/sec
 	// https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html
-	private static final long KINESIS_SHARD_BYTES_PER_SECOND_LIMIT = 2 * 1000000L;
+	private static final long KINESIS_SHARD_BYTES_PER_SECOND_LIMIT = 2 * 1024L * 1024L;
 
 	private final KinesisDeserializationSchema<T> deserializer;
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -235,6 +235,9 @@ public class ShardConsumer<T> implements Runnable {
 						subscribedShard.getShard().getHashKeyRange().getStartingHashKey(),
 						subscribedShard.getShard().getHashKeyRange().getEndingHashKey());
 
+					recordBatchSizeBytes = 0L;
+					averageRecordSizeBytes = 0L;
+
 					for (UserRecord record : fetchedRecords) {
 						recordBatchSizeBytes += record.getData().remaining();
 						deserializeRecordForCollectionAndUpdateState(record);

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisBehavioursFactory.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisBehavioursFactory.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.kinesis.testutils;
 
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.proxy.GetShardListResult;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
@@ -85,6 +86,10 @@ public class FakeKinesisBehavioursFactory {
 		final int numOfRecords, final int numOfGetRecordsCall, final int orderOfCallToExpire) {
 		return new SingleShardEmittingFixNumOfRecordsWithExpiredIteratorKinesis(
 			numOfRecords, numOfGetRecordsCall, orderOfCallToExpire);
+	}
+
+	public static KinesisProxyInterface initialNumOfRecordsAfterNumOfGetRecordsCallsWithAdaptiveReads(final int numOfRecords, final int numOfGetRecordsCalls) {
+		return new SingleShardEmittingFixNumOfRecordsKinesis(numOfRecords, numOfGetRecordsCalls);
 	}
 
 	private static class SingleShardEmittingFixNumOfRecordsWithExpiredIteratorKinesis extends SingleShardEmittingFixNumOfRecordsKinesis {
@@ -204,6 +209,99 @@ public class FakeKinesisBehavioursFactory {
 						.withSequenceNumber(String.valueOf(i)));
 			}
 			return batch;
+		}
+
+	}
+
+	private static class SingleShardEmittingAdaptiveNumOfRecordsKinesis implements
+			KinesisProxyInterface {
+
+		protected final int totalNumOfGetRecordsCalls;
+
+		protected final int totalNumOfRecords;
+
+		protected final Map<String, List<Record>> shardItrToRecordBatch;
+
+		protected static long averageRecordSizeBytes;
+
+		private static final long KINESIS_SHARD_BYTES_PER_SECOND_LIMIT = 2 * 1024L * 1024L;
+
+		public SingleShardEmittingAdaptiveNumOfRecordsKinesis(final int numOfRecords,
+				final int numOfGetRecordsCalls) {
+			this.totalNumOfRecords = numOfRecords;
+			this.totalNumOfGetRecordsCalls = numOfGetRecordsCalls;
+			this.averageRecordSizeBytes = 0L;
+
+			// initialize the record batches that we will be fetched
+			this.shardItrToRecordBatch = new HashMap<>();
+
+			int numOfAlreadyPartitionedRecords = 0;
+			int numOfRecordsPerBatch = numOfRecords;
+			for (int batch = 0; batch < totalNumOfGetRecordsCalls; batch++) {
+					shardItrToRecordBatch.put(
+							String.valueOf(batch),
+							createRecordBatchWithRange(
+									numOfAlreadyPartitionedRecords,
+									numOfAlreadyPartitionedRecords + numOfRecordsPerBatch));
+					numOfAlreadyPartitionedRecords += numOfRecordsPerBatch;
+
+				numOfRecordsPerBatch = (int) (KINESIS_SHARD_BYTES_PER_SECOND_LIMIT /
+						(averageRecordSizeBytes * 1000L / ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_INTERVAL_MILLIS));
+			}
+		}
+
+		@Override
+		public GetRecordsResult getRecords(String shardIterator, int maxRecordsToGet) {
+			// assuming that the maxRecordsToGet is always large enough
+			return new GetRecordsResult()
+					.withRecords(shardItrToRecordBatch.get(shardIterator))
+					.withNextShardIterator(
+							(Integer.valueOf(shardIterator) == totalNumOfGetRecordsCalls - 1)
+									? null : String
+									.valueOf(Integer.valueOf(shardIterator) + 1)); // last next shard iterator is null
+		}
+
+		@Override
+		public String getShardIterator(StreamShardHandle shard, String shardIteratorType,
+				Object startingMarker) {
+			// this will be called only one time per ShardConsumer;
+			// so, simply return the iterator of the first batch of records
+			return "0";
+		}
+
+		@Override
+		public GetShardListResult getShardList(Map<String, String> streamNamesWithLastSeenShardIds) {
+			return null;
+		}
+
+		public static List<Record> createRecordBatchWithRange(int min, int max) {
+			List<Record> batch = new LinkedList<>();
+			long	sumRecordBatchBytes = 0L;
+			// Create record of size 10Kb
+			String data = createDataSize(10 * 1024L);
+
+			for (int i = min; i < max; i++) {
+				Record record = new Record()
+								.withData(
+										ByteBuffer.wrap(String.valueOf(data).getBytes(ConfigConstants.DEFAULT_CHARSET)))
+								.withPartitionKey(UUID.randomUUID().toString())
+								.withApproximateArrivalTimestamp(new Date(System.currentTimeMillis()))
+								.withSequenceNumber(String.valueOf(i));
+				batch.add(record);
+				sumRecordBatchBytes += record.getData().remaining();
+
+			}
+			if (batch.size() != 0) {
+				averageRecordSizeBytes = sumRecordBatchBytes / batch.size();
+			}
+
+			return batch;
+		}
+
+		private static String createDataSize(long msgSize) {
+			char[] data = new char[(int) msgSize];
+			return new String(data);
+
 		}
 
 	}


### PR DESCRIPTION
Previous PR had a bug in the implementation that inflated `averageRecordSizeInBytes` and thus set `maxNumberOfRecordsPerFetch` to 0 in some cases resulting in a ValidationException from AWS. 
