### PR TITLE
[FLINK-9897] Refactor run loop and further enhance adaptive reads to be based on run loop time

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -196,9 +196,9 @@ public class ShardConsumer<T> implements Runnable {
 				}
 			}
 
-			long lastTimeNanos = 0;
-			long runLoopTimeSeconds = 0;
+			long processingStartTimeNanos = System.nanoTime();
 			while (isRunning()) {
+
 				if (nextShardItr == null) {
 					fetcherRef.updateState(subscribedShardStateIndex, SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get());
 
@@ -214,49 +214,70 @@ public class ShardConsumer<T> implements Runnable {
 						subscribedShard.getShard().getHashKeyRange().getEndingHashKey());
 
 					long recordBatchSizeBytes = 0L;
-					long averageRecordSizeBytes = 0L;
-
 					for (UserRecord record : fetchedRecords) {
 						recordBatchSizeBytes += record.getData().remaining();
 						deserializeRecordForCollectionAndUpdateState(record);
 					}
 
-					if (useAdaptiveReads && fetchedRecords.size() != 0) {
-						averageRecordSizeBytes = recordBatchSizeBytes / fetchedRecords.size();
-					}
-
-					// Adjust number of records to fetch from the shard depending on current average record size
-					// to optimize 2 Mb / sec read limits
-					if (useAdaptiveReads) {
-						if (averageRecordSizeBytes != 0 && runLoopTimeSeconds != 0) {
-							maxNumberOfRecordsPerFetch = (int) (KINESIS_SHARD_BYTES_PER_SECOND_LIMIT / (averageRecordSizeBytes / runLoopTimeSeconds));
-
-							// Ensure the value is not more than 10000L
-							maxNumberOfRecordsPerFetch = maxNumberOfRecordsPerFetch <= ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_MAX ?
-									maxNumberOfRecordsPerFetch : ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_MAX;
-						}
-					}
-
-					if (fetchIntervalMillis != 0) {
-							long preSleepTimeNanos = System.nanoTime();
-							long elapsedTimeNanos = preSleepTimeNanos - lastTimeNanos;
-							long sleepTimeMillis = fetchIntervalMillis - (elapsedTimeNanos / 1_000_000);
-
-							if (sleepTimeMillis > 0) {
-								Thread.sleep(sleepTimeMillis);
-							}
-							long postSleepTimeNanos = System.nanoTime();
-
-							runLoopTimeSeconds = (elapsedTimeNanos + (postSleepTimeNanos - preSleepTimeNanos)) / 1_000_000_000;
-							lastTimeNanos = postSleepTimeNanos;
-					}
-
-
 					nextShardItr = getRecordsResult.getNextShardIterator();
+
+					long processingEndTimeNanos = System.nanoTime();
+
+					long adjustmentEndTimeNanos = adjustRunLoopFrequency(processingStartTimeNanos, processingEndTimeNanos);
+					long runLoopTimeNanos = adjustmentEndTimeNanos - processingStartTimeNanos;
+					adaptRecordsToRead(runLoopTimeNanos, fetchedRecords.size(), recordBatchSizeBytes);
+
+					processingStartTimeNanos = adjustmentEndTimeNanos; // for next time through the loop
 				}
 			}
 		} catch (Throwable t) {
 			fetcherRef.stopWithError(t);
+		}
+	}
+
+	/**
+	 * Adjusts loop timing to match target frequency if specified.
+	 * @param processingStartTimeNanos The start time of the run loop "work"
+	 * @param processingEndTimeNanos The end time of the run loop "work"
+	 * @return The System.nanoTime() after the sleep (if any)
+	 * @throws InterruptedException
+	 */
+	private long adjustRunLoopFrequency(long processingStartTimeNanos, long processingEndTimeNanos)
+		throws InterruptedException {
+		long endTimeNanos = processingEndTimeNanos;
+		if (fetchIntervalMillis != 0) {
+			long processingTimeNanos = processingEndTimeNanos - processingStartTimeNanos;
+			long sleepTimeMillis = fetchIntervalMillis - (processingTimeNanos / 1_000_000);
+			if (sleepTimeMillis > 0) {
+				Thread.sleep(sleepTimeMillis);
+				endTimeNanos = System.nanoTime();
+			}
+		}
+		return endTimeNanos;
+	}
+
+	/**
+	 * Calculates how many records to read each time through the loop based on a target throughput
+	 * and the measured frequenecy of the loop.
+	 * @param runLoopTimeNanos The total time of one pass through the loop
+	 * @param numRecords The number of records of the last read operation
+	 * @param recordBatchSizeBytes The total batch size of the last read operation
+	 */
+	private void adaptRecordsToRead(long runLoopTimeNanos, int numRecords, long recordBatchSizeBytes) {
+		if (useAdaptiveReads && numRecords != 0 && runLoopTimeNanos != 0) {
+			long averageRecordSizeBytes = recordBatchSizeBytes / numRecords;
+
+			// Adjust number of records to fetch from the shard depending on current average record size
+			// to optimize 2 Mb / sec read limits
+			double loopFrequencyHz = 1000000000.0d / runLoopTimeNanos;
+			double bytesPerRead = KINESIS_SHARD_BYTES_PER_SECOND_LIMIT / loopFrequencyHz;
+			maxNumberOfRecordsPerFetch = (int) (bytesPerRead / averageRecordSizeBytes);
+
+			// Ensure the value is not more than 10000L
+			maxNumberOfRecordsPerFetch = maxNumberOfRecordsPerFetch
+				<= ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_MAX ?
+				maxNumberOfRecordsPerFetch
+				: ConsumerConfigConstants.DEFAULT_SHARD_GETRECORDS_MAX;
 		}
 	}
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisBehavioursFactory.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisBehavioursFactory.java
@@ -89,7 +89,7 @@ public class FakeKinesisBehavioursFactory {
 	}
 
 	public static KinesisProxyInterface initialNumOfRecordsAfterNumOfGetRecordsCallsWithAdaptiveReads(final int numOfRecords, final int numOfGetRecordsCalls) {
-		return new SingleShardEmittingFixNumOfRecordsKinesis(numOfRecords, numOfGetRecordsCalls);
+		return new SingleShardEmittingAdaptiveNumOfRecordsKinesis(numOfRecords, numOfGetRecordsCalls);
 	}
 
 	private static class SingleShardEmittingFixNumOfRecordsWithExpiredIteratorKinesis extends SingleShardEmittingFixNumOfRecordsKinesis {


### PR DESCRIPTION
The adaptive reads feature maximizes  `maxNumberOfRecordsPerFetch` based on a read frequency 5 reads/sec (as prescribed by Kinesis limits). In the case where applications take more time to process records in the run loop, they are no longer able to read at a frequency of 5 reads/sec (even though their `fetchIntervalMillis` maybe set to 200 ms). In such a scenario, the `maxNumberOfRecordsPerFetch` should be calculated based on the time that the run loop actually takes as opposed to `fetchIntervalMillis`. 