### PR TITLE
[FLINK-9899] Add various Kinesis metrics per-shard per-stream

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/KinesisConsumerMetricConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/KinesisConsumerMetricConstants.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.metrics;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * A collection of consumer metric related constant names.
+ *
+ * <p>The names must not be changed, as that would break backwards compatibility for the consumer metrics.
+ */
+@Internal
+public class KinesisConsumerMetricConstants {
+
+	public static final String KINESIS_CONSUMER_METRICS_GROUP = "KinesisConsumer";
+
+	public static final String STREAM_METRICS_GROUP = "stream";
+	public static final String SHARD_METRICS_GROUP = "shardId";
+
+	public static final String SLEEP_TIME_MILLIS = "sleepTimeMillis";
+	public static final String MAX_RECORDS_PER_FETCH = "maxNumberOfRecordsPerFetch";
+	public static final String NUM_AGGREGATED_RECORDS_PER_FETCH = "numberOfAggregatedRecordsPerFetch";
+	public static final String NUM_DEAGGREGATED_RECORDS_PER_FETCH = "numberOfDeaggregatedRecordsPerFetch";
+	public static final String AVG_RECORD_SIZE_BYTES = "averageRecordSizeBytes";
+	public static final String RUNTIME_LOOP_NANOS = "runLoopTimeNanos";
+	public static final String LOOP_FREQUENCY_HZ = "loopFrequencyHz";
+	public static final String BYTES_PER_READ = "bytesPerFetch";
+
+}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardMetricsReporter.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/metrics/ShardMetricsReporter.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.metrics;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.connectors.kinesis.internals.ShardConsumer;
+
+/**
+ * A container for {@link ShardConsumer}s to report metric values.
+ */
+@Internal
+public class ShardMetricsReporter {
+
+	private volatile double loopFrequencyHz = 0.0;
+	private volatile double bytesPerRead = 0.0;
+	private volatile long runLoopTimeNanos = 0L;
+	private volatile long averageRecordSizeBytes = 0L;
+	private volatile long sleepTimeMillis = 0L;
+	private volatile int numberOfAggregatedRecords = 0;
+	private volatile int numberOfDeaggregatedRecords = 0;
+	private volatile int maxNumberOfRecordsPerFetch = 0;
+
+	public double getLoopFrequencyHz() {
+		return loopFrequencyHz;
+	}
+
+	public void setLoopFrequencyHz(double loopFrequencyHz) {
+		this.loopFrequencyHz = loopFrequencyHz;
+	}
+
+	public double getBytesPerRead() {
+		return bytesPerRead;
+	}
+
+	public void setBytesPerRead(double bytesPerRead) {
+		this.bytesPerRead = bytesPerRead;
+	}
+
+	public long getRunLoopTimeNanos() {
+		return runLoopTimeNanos;
+	}
+
+	public void setRunLoopTimeNanos(long runLoopTimeNanos) {
+		this.runLoopTimeNanos = runLoopTimeNanos;
+	}
+
+	public long getAverageRecordSizeBytes() {
+		return averageRecordSizeBytes;
+	}
+
+	public void setAverageRecordSizeBytes(long averageRecordSizeBytes) {
+		this.averageRecordSizeBytes = averageRecordSizeBytes;
+	}
+
+	public long getSleepTimeMillis() {
+		return sleepTimeMillis;
+	}
+
+	public void setSleepTimeMillis(long sleepTimeMillis) {
+		this.sleepTimeMillis = sleepTimeMillis;
+	}
+
+	public int getNumberOfAggregatedRecords() {
+		return numberOfAggregatedRecords;
+	}
+
+	public void setNumberOfAggregatedRecords(int numberOfAggregatedRecords) {
+		this.numberOfAggregatedRecords = numberOfAggregatedRecords;
+	}
+
+	public int getNumberOfDeaggregatedRecords() {
+		return numberOfDeaggregatedRecords;
+	}
+
+	public void setNumberOfDeaggregatedRecords(int numberOfDeaggregatedRecords) {
+		this.numberOfDeaggregatedRecords = numberOfDeaggregatedRecords;
+	}
+
+	public int getMaxNumberOfRecordsPerFetch() {
+		return maxNumberOfRecordsPerFetch;
+	}
+
+	public void setMaxNumberOfRecordsPerFetch(int maxNumberOfRecordsPerFetch) {
+		this.maxNumberOfRecordsPerFetch = maxNumberOfRecordsPerFetch;
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kinesis.internals;
 
+import org.apache.flink.streaming.connectors.kinesis.metrics.ShardMetricsReporter;
 import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
 import org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
@@ -84,7 +85,7 @@ public class ShardConsumerTest {
 			0,
 			subscribedShardsStateUnderTest.get(0).getStreamShardHandle(),
 			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum(),
-			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(1000, 9)).run();
+			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(1000, 9), new ShardMetricsReporter()).run();
 
 		assertEquals(1000, sourceContext.getCollectedOutputs().size());
 		assertEquals(
@@ -130,7 +131,7 @@ public class ShardConsumerTest {
 			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum(),
 			// Get a total of 1000 records with 9 getRecords() calls,
 			// and the 7th getRecords() call will encounter an unexpected expired shard iterator
-			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(1000, 9, 7)).run();
+			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(1000, 9, 7), new ShardMetricsReporter()).run();
 
 		assertEquals(1000, sourceContext.getCollectedOutputs().size());
 		assertEquals(
@@ -179,7 +180,7 @@ public class ShardConsumerTest {
 			// Start with inital number of records per batch as 10
 			// Make 2 calls to getRecords
 			// Each record is of size 10 Kb
-			FakeKinesisBehavioursFactory.initialNumOfRecordsAfterNumOfGetRecordsCallsWithAdaptiveReads(10, 2)).run();
+			FakeKinesisBehavioursFactory.initialNumOfRecordsAfterNumOfGetRecordsCallsWithAdaptiveReads(10, 2), new ShardMetricsReporter()).run();
 
 		// Avg record size for first batch --> 10 * 10 Kb/10 = 10 Kb
 		// Number of records fetched in second batch --> 2 Mb/10Kb * 5 = 40

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.kinesis.testutils;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kinesis.internals.KinesisDataFetcher;
 import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
@@ -124,7 +125,8 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 				"Fake Task (" + fakeIndexOfThisSubtask + "/" + fakeTotalCountOfSubtasks + ")");
 		Mockito.when(mockedRuntimeContext.getUserCodeClassLoader()).thenReturn(
 				Thread.currentThread().getContextClassLoader());
-
+		Mockito.when(mockedRuntimeContext.getMetricGroup()).thenReturn(
+				new UnregisteredMetricsGroup());
 		return mockedRuntimeContext;
 	}
 }


### PR DESCRIPTION
This PR adds the following metrics at a per-shard level:

-  sleepTimeMillis 
- maxNumberOfRecordsPerFetch
- numberOfAggregatedRecordsPerFetch
- numberOfDeaggregatedRecordsPerFetch
- bytesPerFetch
- averageRecordSizeBytes
- runLoopTimeNanos
- loopFrequencyHz

For the most part I have tried to keep this consistent with[ the way](https://github.com/apache/flink/commit/03841fdece53f0b2264c8a46ae860e7689cabb49) metrics are logged  for the ShardConsumer in Flink versions >= 1.5. This commit cannot be directly cherry-picked because there are some [differences](https://github.com/apache/flink/commit/784dbbeeeb0736c29225b58ec01f1cf95234e881) in the `flink-metrics-core` API.

The PR also modifies unit tests where necessary. 

**Example Dashboard** with new stats: https://lyft.wavefront.com/u/dwf1FS2Pg9