### PR TITLE
[FLINK-9926][Kinesis connector]: add support to allow for plugging in customized ShardCons…

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -297,8 +297,9 @@ public class KinesisDataFetcher<T> {
 					}
 
 				shardConsumersExecutor.submit(
-					new ShardConsumer<>(
+					createShardConsumer(
 						this,
+						configProps,
 						seededStateIndex,
 						subscribedShardsState.get(seededStateIndex).getStreamShardHandle(),
 						subscribedShardsState.get(seededStateIndex).getLastProcessedSequenceNum(),
@@ -344,8 +345,9 @@ public class KinesisDataFetcher<T> {
 				}
 
 				shardConsumersExecutor.submit(
-					new ShardConsumer<>(
+					createShardConsumer(
 						this,
+						configProps,
 						newStateIndex,
 						newShardState.getStreamShardHandle(),
 						newShardState.getLastProcessedSequenceNum(),
@@ -426,7 +428,6 @@ public class KinesisDataFetcher<T> {
 			shutdownFetcher();
 		}
 	}
-
 	// ------------------------------------------------------------------------
 	//  Functions that update the subscribedStreamToLastDiscoveredShardIds state
 	// ------------------------------------------------------------------------
@@ -445,7 +446,33 @@ public class KinesisDataFetcher<T> {
 		}
 	}
 
-	/**
+  /**
+   * Function to create new shard consumer (can be overriden to embed customized KinesisProxy).
+   *
+   * @param fetcherRef reference to data fetcher
+   * @param consumerConfigProps config properties of the shard consumer
+   * @param subscribedShardStateIndex index in subscribed shard state
+   * @param handle handle of the shard consumer stream
+   * @param lastSeqNum last processed sequence number of the stream
+   * @return
+   */
+  protected ShardConsumer createShardConsumer(
+      KinesisDataFetcher fetcherRef,
+      Properties consumerConfigProps,
+      int subscribedShardStateIndex,
+      StreamShardHandle handle,
+      SequenceNumber lastSeqNum,
+      ShardMetricsReporter shardMetricsReporter) {
+    return new ShardConsumer<>(
+        fetcherRef,
+        consumerConfigProps,
+        subscribedShardStateIndex,
+        handle,
+        lastSeqNum,
+        shardMetricsReporter);
+  }
+
+  /**
 	 * A utility function that does the following:
 	 *
 	 * <p>1. Find new shards for each stream that we haven't seen before

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -90,6 +90,7 @@ public class ShardConsumer<T> implements Runnable {
 	 * @param shardMetricsReporter the reporter to report metrics to
 	 */
 	public ShardConsumer(KinesisDataFetcher<T> fetcherRef,
+						Properties consumerConfigProps,
 						Integer subscribedShardStateIndex,
 						StreamShardHandle subscribedShard,
 						SequenceNumber lastSequenceNum,
@@ -98,7 +99,7 @@ public class ShardConsumer<T> implements Runnable {
 			subscribedShardStateIndex,
 			subscribedShard,
 			lastSequenceNum,
-			KinesisProxy.create(fetcherRef.getConsumerConfiguration()),
+			KinesisProxy.create(consumerConfigProps),
 			shardMetricsReporter);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces a new function `createShardConsumer`, which allows people to pass in customized `ShardConsumer` inside the flink-kinesis connector

## Brief change log

A new constructor function `createShardConsumer` is introduced. Derived classes of `KinesisDataFetcher` can override this class to plug in customized `ShardConsumer` object. 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
