### PR TITLE
[FLINK-9926][Kinesis connector]: add support to allow for plugging in customized ShardCons…

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -33,9 +33,9 @@ under the License.
 	<artifactId>flink-connector-kinesis_${scala.binary.version}</artifactId>
 	<name>flink-connector-kinesis</name>
 	<properties>
-		<aws.sdk.version>1.11.272</aws.sdk.version>
-		<aws.kinesis-kcl.version>1.8.1</aws.kinesis-kcl.version>
-		<aws.kinesis-kpl.version>0.12.5</aws.kinesis-kpl.version>
+		<aws.sdk.version>1.11.319</aws.sdk.version>
+		<aws.kinesis-kcl.version>1.9.0</aws.kinesis-kcl.version>
+		<aws.kinesis-kpl.version>0.12.9</aws.kinesis-kpl.version>
 	</properties>
 
 	<packaging>jar</packaging>

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -441,7 +441,6 @@ public class KinesisDataFetcher<T> {
 	/**
 	 * Function to create new shard consumer (can be overriden to embed customized KinesisProxy).
 	 *
-	 * @param consumerConfigProps config properties of the shard consumer
 	 * @param subscribedShardStateIndex index in subscribed shard state
 	 * @param handle handle of the shard consumer stream
 	 * @param lastSeqNum last processed sequence number of the stream
@@ -455,10 +454,10 @@ public class KinesisDataFetcher<T> {
 		ShardMetricsReporter shardMetricsReporter) {
 		return new ShardConsumer<>(
 			this,
-			consumerConfigProps,
 			subscribedShardStateIndex,
 			handle,
 			lastSeqNum,
+			KinesisProxy.create(consumerConfigProps),
 			shardMetricsReporter);
 	}
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -291,9 +291,8 @@ public class KinesisDataFetcher<T> {
 					}
 
 				shardConsumersExecutor.submit(
-					createShardConsumer(
+					new ShardConsumer<>(
 						this,
-						configProps,
 						seededStateIndex,
 						subscribedShardsState.get(seededStateIndex).getStreamShardHandle(),
 						subscribedShardsState.get(seededStateIndex).getLastProcessedSequenceNum(),
@@ -339,9 +338,8 @@ public class KinesisDataFetcher<T> {
 				}
 
 				shardConsumersExecutor.submit(
-					createShardConsumer(
+					new ShardConsumer<>(
 						this,
-						configProps,
 						newStateIndex,
 						newShardState.getStreamShardHandle(),
 						newShardState.getLastProcessedSequenceNum(),
@@ -422,6 +420,7 @@ public class KinesisDataFetcher<T> {
 			shutdownFetcher();
 		}
 	}
+
 	// ------------------------------------------------------------------------
 	//  Functions that update the subscribedStreamToLastDiscoveredShardIds state
 	// ------------------------------------------------------------------------
@@ -440,33 +439,7 @@ public class KinesisDataFetcher<T> {
 		}
 	}
 
-  /**
-   * Function to create new shard consumer (can be overriden to embed customized KinesisProxy).
-   *
-   * @param fetcherRef reference to data fetcher
-   * @param consumerConfigProps config properties of the shard consumer
-   * @param subscribedShardStateIndex index in subscribed shard state
-   * @param handle handle of the shard consumer stream
-   * @param lastSeqNum last processed sequence number of the stream
-   * @return
-   */
-  protected ShardConsumer createShardConsumer(
-      KinesisDataFetcher fetcherRef,
-      Properties consumerConfigProps,
-      int subscribedShardStateIndex,
-      StreamShardHandle handle,
-      SequenceNumber lastSeqNum,
-      ShardMetricsReporter shardMetricsReporter) {
-    return new ShardConsumer<>(
-        fetcherRef,
-        consumerConfigProps,
-        subscribedShardStateIndex,
-        handle,
-        lastSeqNum,
-        shardMetricsReporter);
-  }
-
-  /**
+	/**
 	 * A utility function that does the following:
 	 *
 	 * <p>1. Find new shards for each stream that we haven't seen before

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -442,6 +442,7 @@ public class KinesisDataFetcher<T> {
 	 * @param subscribedShardStateIndex index in subscribed shard state
 	 * @param handle handle of the shard consumer stream
 	 * @param lastSeqNum last processed sequence number of the stream
+	 * @param shardMetricsReporter the reporter to report shard metrics to
 	 * @return new shard consumer object
 	 */
 	protected ShardConsumer createShardConsumer(

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -291,8 +291,9 @@ public class KinesisDataFetcher<T> {
 					}
 
 				shardConsumersExecutor.submit(
-					new ShardConsumer<>(
+					createShardConsumer(
 						this,
+						configProps,
 						seededStateIndex,
 						subscribedShardsState.get(seededStateIndex).getStreamShardHandle(),
 						subscribedShardsState.get(seededStateIndex).getLastProcessedSequenceNum(),
@@ -338,8 +339,9 @@ public class KinesisDataFetcher<T> {
 				}
 
 				shardConsumersExecutor.submit(
-					new ShardConsumer<>(
+					createShardConsumer(
 						this,
+						configProps,
 						newStateIndex,
 						newShardState.getStreamShardHandle(),
 						newShardState.getLastProcessedSequenceNum(),
@@ -420,7 +422,6 @@ public class KinesisDataFetcher<T> {
 			shutdownFetcher();
 		}
 	}
-
 	// ------------------------------------------------------------------------
 	//  Functions that update the subscribedStreamToLastDiscoveredShardIds state
 	// ------------------------------------------------------------------------
@@ -439,7 +440,33 @@ public class KinesisDataFetcher<T> {
 		}
 	}
 
-	/**
+  /**
+   * Function to create new shard consumer (can be overriden to embed customized KinesisProxy).
+   *
+   * @param fetcherRef reference to data fetcher
+   * @param consumerConfigProps config properties of the shard consumer
+   * @param subscribedShardStateIndex index in subscribed shard state
+   * @param handle handle of the shard consumer stream
+   * @param lastSeqNum last processed sequence number of the stream
+   * @return
+   */
+  protected ShardConsumer createShardConsumer(
+      KinesisDataFetcher fetcherRef,
+      Properties consumerConfigProps,
+      int subscribedShardStateIndex,
+      StreamShardHandle handle,
+      SequenceNumber lastSeqNum,
+      ShardMetricsReporter shardMetricsReporter) {
+    return new ShardConsumer<>(
+        fetcherRef,
+        consumerConfigProps,
+        subscribedShardStateIndex,
+        handle,
+        lastSeqNum,
+        shardMetricsReporter);
+  }
+
+  /**
 	 * A utility function that does the following:
 	 *
 	 * <p>1. Find new shards for each stream that we haven't seen before

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -440,33 +440,33 @@ public class KinesisDataFetcher<T> {
 		}
 	}
 
-  /**
-   * Function to create new shard consumer (can be overriden to embed customized KinesisProxy).
-   *
-   * @param fetcherRef reference to data fetcher
-   * @param consumerConfigProps config properties of the shard consumer
-   * @param subscribedShardStateIndex index in subscribed shard state
-   * @param handle handle of the shard consumer stream
-   * @param lastSeqNum last processed sequence number of the stream
-   * @return
-   */
-  protected ShardConsumer createShardConsumer(
-      KinesisDataFetcher fetcherRef,
-      Properties consumerConfigProps,
-      int subscribedShardStateIndex,
-      StreamShardHandle handle,
-      SequenceNumber lastSeqNum,
-      ShardMetricsReporter shardMetricsReporter) {
-    return new ShardConsumer<>(
-        fetcherRef,
-        consumerConfigProps,
-        subscribedShardStateIndex,
-        handle,
-        lastSeqNum,
-        shardMetricsReporter);
-  }
+	/**
+	 * Function to create new shard consumer (can be overriden to embed customized KinesisProxy).
+	 *
+	 * @param fetcherRef reference to data fetcher
+	 * @param consumerConfigProps config properties of the shard consumer
+	 * @param subscribedShardStateIndex index in subscribed shard state
+	 * @param handle handle of the shard consumer stream
+	 * @param lastSeqNum last processed sequence number of the stream
+	 * @return new shard consumer object
+	 */
+	protected ShardConsumer createShardConsumer(
+		KinesisDataFetcher fetcherRef,
+		Properties consumerConfigProps,
+		int subscribedShardStateIndex,
+		StreamShardHandle handle,
+		SequenceNumber lastSeqNum,
+		ShardMetricsReporter shardMetricsReporter) {
+		return new ShardConsumer<>(
+			fetcherRef,
+			consumerConfigProps,
+			subscribedShardStateIndex,
+			handle,
+			lastSeqNum,
+			shardMetricsReporter);
+	}
 
-  /**
+	/**
 	 * A utility function that does the following:
 	 *
 	 * <p>1. Find new shards for each stream that we haven't seen before

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -292,7 +292,6 @@ public class KinesisDataFetcher<T> {
 
 				shardConsumersExecutor.submit(
 					createShardConsumer(
-						configProps,
 						seededStateIndex,
 						subscribedShardsState.get(seededStateIndex).getStreamShardHandle(),
 						subscribedShardsState.get(seededStateIndex).getLastProcessedSequenceNum(),
@@ -339,7 +338,6 @@ public class KinesisDataFetcher<T> {
 
 				shardConsumersExecutor.submit(
 					createShardConsumer(
-						configProps,
 						newStateIndex,
 						newShardState.getStreamShardHandle(),
 						newShardState.getLastProcessedSequenceNum(),
@@ -447,7 +445,6 @@ public class KinesisDataFetcher<T> {
 	 * @return new shard consumer object
 	 */
 	protected ShardConsumer createShardConsumer(
-		Properties consumerConfigProps,
 		int subscribedShardStateIndex,
 		StreamShardHandle handle,
 		SequenceNumber lastSeqNum,
@@ -457,7 +454,7 @@ public class KinesisDataFetcher<T> {
 			subscribedShardStateIndex,
 			handle,
 			lastSeqNum,
-			KinesisProxy.create(consumerConfigProps),
+			KinesisProxy.create(configProps),
 			shardMetricsReporter);
 	}
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -441,7 +441,6 @@ public class KinesisDataFetcher<T> {
 	/**
 	 * Function to create new shard consumer (can be overriden to embed customized KinesisProxy).
 	 *
-	 * @param fetcherRef reference to data fetcher
 	 * @param consumerConfigProps config properties of the shard consumer
 	 * @param subscribedShardStateIndex index in subscribed shard state
 	 * @param handle handle of the shard consumer stream

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -292,7 +292,6 @@ public class KinesisDataFetcher<T> {
 
 				shardConsumersExecutor.submit(
 					createShardConsumer(
-						this,
 						configProps,
 						seededStateIndex,
 						subscribedShardsState.get(seededStateIndex).getStreamShardHandle(),
@@ -340,7 +339,6 @@ public class KinesisDataFetcher<T> {
 
 				shardConsumersExecutor.submit(
 					createShardConsumer(
-						this,
 						configProps,
 						newStateIndex,
 						newShardState.getStreamShardHandle(),
@@ -451,14 +449,13 @@ public class KinesisDataFetcher<T> {
 	 * @return new shard consumer object
 	 */
 	protected ShardConsumer createShardConsumer(
-		KinesisDataFetcher fetcherRef,
 		Properties consumerConfigProps,
 		int subscribedShardStateIndex,
 		StreamShardHandle handle,
 		SequenceNumber lastSeqNum,
 		ShardMetricsReporter shardMetricsReporter) {
 		return new ShardConsumer<>(
-			fetcherRef,
+			this,
 			consumerConfigProps,
 			subscribedShardStateIndex,
 			handle,

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -88,7 +88,6 @@ public class ShardConsumer<T> implements Runnable {
 	 * @param lastSequenceNum the sequence number in the shard to start consuming
 	 */
 	public ShardConsumer(KinesisDataFetcher<T> fetcherRef,
-						Properties consumerConfigProps,
 						Integer subscribedShardStateIndex,
 						StreamShardHandle subscribedShard,
 						SequenceNumber lastSequenceNum,
@@ -97,7 +96,7 @@ public class ShardConsumer<T> implements Runnable {
 			subscribedShardStateIndex,
 			subscribedShard,
 			lastSequenceNum,
-			KinesisProxy.create(consumerConfigProps),
+			KinesisProxy.create(fetcherRef.getConsumerConfiguration()),
 			shardMetricsReporter);
 	}
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -23,7 +23,6 @@ import org.apache.flink.streaming.connectors.kinesis.metrics.ShardMetricsReporte
 import org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
-import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxy;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
 
@@ -86,28 +85,15 @@ public class ShardConsumer<T> implements Runnable {
 	 * @param subscribedShardStateIndex the state index of the shard this consumer is subscribed to
 	 * @param subscribedShard the shard this consumer is subscribed to
 	 * @param lastSequenceNum the sequence number in the shard to start consuming
+	 * @param kinesis the kinesis proxy interface
+	 * @param shardMetricsReporter the reporter to report shard metrics to
 	 */
 	public ShardConsumer(KinesisDataFetcher<T> fetcherRef,
-						Properties consumerConfigProps,
 						Integer subscribedShardStateIndex,
 						StreamShardHandle subscribedShard,
 						SequenceNumber lastSequenceNum,
+						KinesisProxyInterface kinesis,
 						ShardMetricsReporter shardMetricsReporter) {
-		this(fetcherRef,
-			subscribedShardStateIndex,
-			subscribedShard,
-			lastSequenceNum,
-			KinesisProxy.create(consumerConfigProps),
-			shardMetricsReporter);
-	}
-
-	/** This constructor is exposed for testing purposes. */
-	protected ShardConsumer(KinesisDataFetcher<T> fetcherRef,
-							Integer subscribedShardStateIndex,
-							StreamShardHandle subscribedShard,
-							SequenceNumber lastSequenceNum,
-							KinesisProxyInterface kinesis,
-							ShardMetricsReporter shardMetricsReporter) {
 		this.fetcherRef = checkNotNull(fetcherRef);
 		this.subscribedShardStateIndex = checkNotNull(subscribedShardStateIndex);
 		this.subscribedShard = checkNotNull(subscribedShard);

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -88,6 +88,7 @@ public class ShardConsumer<T> implements Runnable {
 	 * @param lastSequenceNum the sequence number in the shard to start consuming
 	 */
 	public ShardConsumer(KinesisDataFetcher<T> fetcherRef,
+						Properties consumerConfigProps,
 						Integer subscribedShardStateIndex,
 						StreamShardHandle subscribedShard,
 						SequenceNumber lastSequenceNum,
@@ -96,7 +97,7 @@ public class ShardConsumer<T> implements Runnable {
 			subscribedShardStateIndex,
 			subscribedShard,
 			lastSequenceNum,
-			KinesisProxy.create(fetcherRef.getConsumerConfiguration()),
+			KinesisProxy.create(consumerConfigProps),
 			shardMetricsReporter);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces a new function `createShardConsumer`, which allows people to pass in customized `ShardConsumer` inside the flink-kinesis connector.

Completion of this PR in the lyft/flink `release-lyft-1.4` branch is necessary to unblock [a related PR](https://github.com/lyft/streamingplatform/pull/253) in `streamingplatform`  

## Brief change log

A new constructor function `createShardConsumer` is introduced. Derived classes of `KinesisDataFetcher` can override this class to plug in customized `ShardConsumer` object. 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
