### PR TITLE
[FLINK-10358][Kinesis-connector] fix NPE in case millisBehindLatest is null

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -373,7 +373,10 @@ public class ShardConsumer<T> implements Runnable {
 				getRecordsResult = kinesis.getRecords(shardItr, maxNumberOfRecords);
 
 				// Update millis behind latest so it gets reported by the millisBehindLatest gauge
-				shardMetricsReporter.setMillisBehindLatest(getRecordsResult.getMillisBehindLatest());
+				Long millisBehindLatest = getRecordsResult.getMillisBehindLatest();
+				if (millisBehindLatest != null) {
+					shardMetricsReporter.setMillisBehindLatest(millisBehindLatest);
+				}
 			} catch (ExpiredIteratorException eiEx) {
 				LOG.warn("Encountered an unexpected expired iterator {} for shard {};" +
 					" refreshing the iterator ...", shardItr, subscribedShard);


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the NPE described in [Flink-10358](https://issues.apache.org/jira/browse/FLINK-10358).

## Brief change log

Check to avoid NPE inside ShardConsumer.java.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)
