### PR TITLE
[STRMCMP-261] : Backport and refactor of [FLINK-9061] Adding Entropy Injection support for S3/Hadoop FileSystem

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/AbstractEntropyInjectingFileSystemBase.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/AbstractEntropyInjectingFileSystemBase.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.util.StringUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+
+/**
+ * Base class for entropy injecting FileSystems.
+ */
+public abstract class AbstractEntropyInjectingFileSystemBase extends FileSystem implements
+	EntropyInjectingFileSystem {
+
+	/**
+	 * The substring to be replaced by random entropy in checkpoint paths.
+	 */
+	public static final ConfigOption<String> ENTROPY_INJECT_KEY_OPTION = ConfigOptions
+		.key("s3.entropy.key")
+		.noDefaultValue()
+		.withDescription(
+			"This option can be used to improve performance due to sharding issues on Amazon S3. " +
+				"For file creations with entropy injection, this key will be replaced by random " +
+				"alphanumeric characters. For other file creations, the key will be filtered out.");
+
+	/**
+	 * The number of entropy characters, in case entropy injection is configured.
+	 */
+	public static final ConfigOption<Integer> ENTROPY_INJECT_LENGTH_OPTION = ConfigOptions
+		.key("s3.entropy.length")
+		.defaultValue(4)
+		.withDescription(
+			"When '" + ENTROPY_INJECT_KEY_OPTION.key()
+				+ "' is set, this option defines the number of " +
+				"random characters to replace the entropy key with.");
+
+	// ------------------------------------------------------------------------
+
+	private static final String INVALID_ENTROPY_KEY_CHARS = "^.*[~#@*+%{}<>\\[\\]|\"\\\\].*$";
+
+	private static final Logger LOG = LoggerFactory
+		.getLogger(AbstractEntropyInjectingFileSystemBase.class);
+
+	@Nullable
+	private final String entropyInjectionKey;
+
+	private int entropyLength;
+
+	protected AbstractEntropyInjectingFileSystemBase(Configuration flinkConfig) {
+
+		if (flinkConfig == null) {
+			flinkConfig = new Configuration();
+			LOG.warn("Creating entropy injecting filesystem with no configuration.  Will use defaults.");
+		}
+
+		// load the entropy injection settings
+		this.entropyInjectionKey = flinkConfig.getString(ENTROPY_INJECT_KEY_OPTION);
+		this.entropyLength = -1;
+		if (entropyInjectionKey != null) {
+			if (entropyInjectionKey.matches(INVALID_ENTROPY_KEY_CHARS)) {
+				throw new IllegalConfigurationException("Invalid character in value for " +
+					ENTROPY_INJECT_KEY_OPTION.key() + " : " + entropyInjectionKey);
+			}
+			this.entropyLength = flinkConfig.getInteger(ENTROPY_INJECT_LENGTH_OPTION);
+			if (this.entropyLength <= 0) {
+				throw new IllegalConfigurationException(
+					ENTROPY_INJECT_LENGTH_OPTION.key() + " must configure a value > 0");
+			}
+		}
+	}
+
+	//--------------------------------------------------
+	// Entropy Injection
+	//--------------------------------------------------
+
+	@Nullable
+	@Override
+	public String getEntropyInjectionKey() {
+		return entropyInjectionKey;
+	}
+
+	@Override
+	public String generateEntropy() {
+		return StringUtils
+			.generateRandomAlphanumericString(ThreadLocalRandom.current(), entropyLength);
+	}
+
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/ConnectionLimitingFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/ConnectionLimitingFactory.java
@@ -37,6 +37,8 @@ public class ConnectionLimitingFactory implements FileSystemFactory {
 
 	private final ConnectionLimitingSettings settings;
 
+	private Configuration flinkConfig;
+
 	private ConnectionLimitingFactory(
 			FileSystemFactory factory,
 			ConnectionLimitingSettings settings) {
@@ -55,6 +57,7 @@ public class ConnectionLimitingFactory implements FileSystemFactory {
 	@Override
 	public void configure(Configuration config) {
 		factory.configure(config);
+		flinkConfig = config;
 	}
 
 	@Override
@@ -62,7 +65,7 @@ public class ConnectionLimitingFactory implements FileSystemFactory {
 		FileSystem original = factory.create(fsUri);
 		return new LimitedConnectionsFileSystem(original,
 				settings.limitTotal, settings.limitOutput, settings.limitInput,
-				settings.streamOpenTimeout, settings.streamInactivityTimeout);
+				settings.streamOpenTimeout, settings.streamInactivityTimeout, flinkConfig);
 	}
 
 	// ------------------------------------------------------------------------
@@ -89,7 +92,9 @@ public class ConnectionLimitingFactory implements FileSystemFactory {
 			return factory;
 		}
 		else {
-			return new ConnectionLimitingFactory(factory, settings);
+			ConnectionLimitingFactory connectionLimitingFactory = new ConnectionLimitingFactory(factory, settings);
+			connectionLimitingFactory.flinkConfig = config;
+			return connectionLimitingFactory;
 		}
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjectingFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjectingFileSystem.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * An interface to be implemented by a {@link FileSystem} that is aware of entropy injection.
+ *
+ * <p>Entropy injection is a technique to spread files/objects across more parallel shards of
+ * a distributed storage (typically object store) by adding random characters to the beginning
+ * of the path/key and hence spearing the keys across a wider domain of prefixes.
+ *
+ * <p>Entropy injection typically works by having a recognized marker string in paths
+ * and replacing that marker with random characters.
+ *
+ * <p>This interface is used in conjunction with the {@link EntropyInjector} (as a poor man's
+ * way to build a mix-in in Java).
+ */
+@PublicEvolving
+public interface EntropyInjectingFileSystem {
+
+	/**
+	 * Gets the marker string that represents the substring of a path to be replaced
+	 * by the entropy characters.
+	 */
+	String getEntropyInjectionKey();
+
+	/**
+	 * Creates a string with random entropy to be injected into a path.
+	 */
+	String generateEntropy();
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjector.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjector.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.fs.FileSystem.WriteMode;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * This class offers utilities for entropy injection for FileSystems that implement
+ * {@link EntropyInjectingFileSystem}.
+ */
+@PublicEvolving
+public class EntropyInjector {
+
+	/**
+	 * Handles entropy injection across regular and entropy-aware file systems.
+	 *
+	 * <p>If the given file system is entropy-aware (a implements {@link EntropyInjectingFileSystem}),
+	 * then this method replaces the entropy marker in the path with random characters.
+	 * The entropy marker is defined by {@link EntropyInjectingFileSystem#getEntropyInjectionKey()}.
+	 *
+	 * <p>If the given file system does not implement {@code EntropyInjectingFileSystem},
+	 * then this method delegates to {@link FileSystem#create(Path, WriteMode)} and
+	 * returns the same path in the resulting {@code OutputStreamAndPath}.
+	 */
+	public static OutputStreamAndPath createEntropyAware(
+			FileSystem fs,
+			Path path,
+			WriteMode writeMode) throws IOException {
+
+		// check and possibly inject entropy into the path
+		final EntropyInjectingFileSystem efs = getEntropyFs(fs);
+		final Path processedPath = efs == null ? path : resolveEntropy(path, efs, true);
+
+		// create the stream on the original file system to let the safety net
+		// take its effect
+		final FSDataOutputStream out = fs.create(processedPath, writeMode);
+		return new OutputStreamAndPath(out, processedPath);
+	}
+
+	/**
+	 * Removes the entropy marker string from the path, if the given file system is an
+	 * entropy-injecting file system (implements {@link EntropyInjectingFileSystem}) and
+	 * the entropy marker key is present. Otherwise, this returns the path as is.
+	 *
+	 * @param path The path to filter.
+	 * @return The path without the marker string.
+	 */
+	public static Path removeEntropyMarkerIfPresent(FileSystem fs, Path path) {
+		final EntropyInjectingFileSystem efs = getEntropyFs(fs);
+		if (efs == null) {
+			return path;
+		}
+		else  {
+			try {
+				return resolveEntropy(path, efs, false);
+			}
+			catch (IOException e) {
+				// this should never happen, because the path was valid before and we only remove characters.
+				// rethrow to silence the compiler
+				throw new FlinkRuntimeException(e.getMessage(), e);
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Nullable
+	private static EntropyInjectingFileSystem getEntropyFs(FileSystem fs) {
+		if (fs instanceof EntropyInjectingFileSystem) {
+			return (EntropyInjectingFileSystem) fs;
+		}
+		else if (fs instanceof SafetyNetWrapperFileSystem) {
+			FileSystem delegate = ((SafetyNetWrapperFileSystem) fs).getWrappedDelegate();
+			if (delegate instanceof EntropyInjectingFileSystem) {
+				return (EntropyInjectingFileSystem) delegate;
+			}
+			else {
+				return null;
+			}
+		}
+		else {
+			return null;
+		}
+	}
+
+	@VisibleForTesting
+	static Path resolveEntropy(Path path, EntropyInjectingFileSystem efs, boolean injectEntropy) throws IOException {
+		final String entropyInjectionKey = efs.getEntropyInjectionKey();
+
+		if (entropyInjectionKey == null) {
+			return path;
+		}
+		else {
+			final URI originalUri = path.toUri();
+			final String checkpointPath = originalUri.getPath();
+
+			final int indexOfKey = checkpointPath.indexOf(entropyInjectionKey);
+			if (indexOfKey == -1) {
+				return path;
+			}
+			else {
+				final StringBuilder buffer = new StringBuilder(checkpointPath.length());
+				buffer.append(checkpointPath, 0, indexOfKey);
+
+				if (injectEntropy) {
+					buffer.append(efs.generateEntropy());
+				}
+
+				buffer.append(checkpointPath, indexOfKey + entropyInjectionKey.length(), checkpointPath.length());
+
+				final String rewrittenPath = buffer.toString();
+				try {
+					return new Path(new URI(
+							originalUri.getScheme(),
+							originalUri.getAuthority(),
+							rewrittenPath,
+							originalUri.getQuery(),
+							originalUri.getFragment()).normalize());
+				}
+				catch (URISyntaxException e) {
+					// this could only happen if the injected entropy string contains invalid characters
+					throw new IOException("URI format error while processing path for entropy injection", e);
+				}
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	/** This class is not meant to be instantiated. */
+	private EntropyInjector() {}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java
@@ -60,7 +60,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * periodically check the currently open streams once the limit of open streams is reached.
  */
 @Internal
-public class LimitedConnectionsFileSystem extends FileSystem {
+public class LimitedConnectionsFileSystem extends AbstractEntropyInjectingFileSystemBase {
 
 	private static final Logger LOG = LoggerFactory.getLogger(LimitedConnectionsFileSystem.class);
 
@@ -116,8 +116,8 @@ public class LimitedConnectionsFileSystem extends FileSystem {
 	 * @param originalFs              The original file system to which connections are limited.
 	 * @param maxNumOpenStreamsTotal  The maximum number of concurrent open streams (0 means no limit).
 	 */
-	public LimitedConnectionsFileSystem(FileSystem originalFs, int maxNumOpenStreamsTotal) {
-		this(originalFs, maxNumOpenStreamsTotal, 0, 0);
+	public LimitedConnectionsFileSystem(FileSystem originalFs, int maxNumOpenStreamsTotal, Configuration flinkConfig) {
+		this(originalFs, maxNumOpenStreamsTotal, 0, 0, flinkConfig);
 	}
 
 	/**
@@ -138,8 +138,9 @@ public class LimitedConnectionsFileSystem extends FileSystem {
 			FileSystem originalFs,
 			int maxNumOpenStreamsTotal,
 			long streamOpenTimeout,
-			long streamInactivityTimeout) {
-		this(originalFs, maxNumOpenStreamsTotal, 0, 0, streamOpenTimeout, streamInactivityTimeout);
+			long streamInactivityTimeout,
+			Configuration flinkConfig) {
+		this(originalFs, maxNumOpenStreamsTotal, 0, 0, streamOpenTimeout, streamInactivityTimeout, flinkConfig);
 	}
 
 	/**
@@ -165,8 +166,10 @@ public class LimitedConnectionsFileSystem extends FileSystem {
 			int maxNumOpenOutputStreams,
 			int maxNumOpenInputStreams,
 			long streamOpenTimeout,
-			long streamInactivityTimeout) {
+			long streamInactivityTimeout,
+			Configuration flinkConfig) {
 
+		super(flinkConfig);
 		checkArgument(maxNumOpenStreamsTotal >= 0, "maxNumOpenStreamsTotal must be >= 0");
 		checkArgument(maxNumOpenOutputStreams >= 0, "maxNumOpenOutputStreams must be >= 0");
 		checkArgument(maxNumOpenInputStreams >= 0, "maxNumOpenInputStreams must be >= 0");

--- a/flink-core/src/main/java/org/apache/flink/core/fs/OutputStreamAndPath.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/OutputStreamAndPath.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An output stream and a path.
+ */
+public final class OutputStreamAndPath {
+
+	private final FSDataOutputStream stream;
+
+	private final Path path;
+
+	/**
+	 * Creates a OutputStreamAndPath.
+	 */
+	public OutputStreamAndPath(FSDataOutputStream stream, Path path) {
+		this.stream = checkNotNull(stream);
+		this.path = checkNotNull(path);
+	}
+
+	public FSDataOutputStream stream() {
+		return stream;
+	}
+
+	public Path path() {
+		return path;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -95,6 +96,38 @@ public final class StringUtils {
 			bts[i] = (byte) Integer.parseInt(hex.substring(2 * i, 2 * i + 2), 16);
 		}
 		return bts;
+	}
+
+	/**
+	 * Creates a random alphanumeric string of given length.
+	 *
+	 * @param rnd The random number generator to use.
+	 * @param length The number of alphanumeric characters to append.
+	 */
+	public static String generateRandomAlphanumericString(Random rnd, int length) {
+		checkNotNull(rnd);
+		checkArgument(length >= 0);
+
+		StringBuilder buffer = new StringBuilder(length);
+		for (int i = 0; i < length; i++) {
+			buffer.append(nextAlphanumericChar(rnd));
+		}
+		return buffer.toString();
+	}
+
+	private static char nextAlphanumericChar(Random rnd) {
+		int which = rnd.nextInt(62);
+		char c;
+		if (which < 10) {
+			c = (char) ('0' + which);
+		}
+		else if (which < 36) {
+			c = (char) ('A' - 10 + which);
+		}
+		else {
+			c = (char) ('a' - 36 + which);
+		}
+		return c;
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.core.fs.FileSystem.WriteMode;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link EntropyInjector}.
+ */
+public class EntropyInjectorTest {
+
+	@ClassRule
+	public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+	@Test
+	public void testEmptyPath() throws Exception {
+		EntropyInjectingFileSystem efs = new TestEntropyInjectingFs("test", "ignored");
+		Path path = new Path("hdfs://localhost:12345");
+
+		assertEquals(path, EntropyInjector.resolveEntropy(path, efs, true));
+		assertEquals(path, EntropyInjector.resolveEntropy(path, efs, false));
+	}
+
+	@Test
+	public void testFullUriNonMatching() throws Exception {
+		EntropyInjectingFileSystem efs = new TestEntropyInjectingFs("_entropy_key_", "ignored");
+		Path path = new Path("s3://hugo@myawesomehost:55522/path/to/the/file");
+
+		assertEquals(path, EntropyInjector.resolveEntropy(path, efs, true));
+		assertEquals(path, EntropyInjector.resolveEntropy(path, efs, false));
+	}
+
+	@Test
+	public void testFullUriMatching() throws Exception {
+		EntropyInjectingFileSystem efs = new TestEntropyInjectingFs("s0mek3y", "12345678");
+		Path path = new Path("s3://hugo@myawesomehost:55522/path/s0mek3y/the/file");
+
+		assertEquals(new Path("s3://hugo@myawesomehost:55522/path/12345678/the/file"), EntropyInjector
+			.resolveEntropy(path, efs, true));
+		assertEquals(new Path("s3://hugo@myawesomehost:55522/path/the/file"), EntropyInjector
+			.resolveEntropy(path, efs, false));
+	}
+
+	@Test
+	public void testPathOnlyNonMatching() throws Exception {
+		EntropyInjectingFileSystem efs = new TestEntropyInjectingFs("_entropy_key_", "ignored");
+		Path path = new Path("/path/file");
+
+		assertEquals(path, EntropyInjector.resolveEntropy(path, efs, true));
+		assertEquals(path, EntropyInjector.resolveEntropy(path, efs, false));
+	}
+
+	@Test
+	public void testPathOnlyMatching() throws Exception {
+		EntropyInjectingFileSystem efs = new TestEntropyInjectingFs("_entropy_key_", "xyzz");
+		Path path = new Path("/path/_entropy_key_/file");
+
+		assertEquals(new Path("/path/xyzz/file"), EntropyInjector.resolveEntropy(path, efs, true));
+		assertEquals(new Path("/path/file"), EntropyInjector.resolveEntropy(path, efs, false));
+	}
+
+	@Test
+	public void testEntropyNotFullSegment() throws Exception {
+		EntropyInjectingFileSystem efs = new TestEntropyInjectingFs("_entropy_key_", "pqr");
+		Path path = new Path("s3://myhost:122/entropy-_entropy_key_-suffix/file");
+
+		assertEquals(new Path("s3://myhost:122/entropy-pqr-suffix/file"), EntropyInjector
+			.resolveEntropy(path, efs, true));
+		assertEquals(new Path("s3://myhost:122/entropy--suffix/file"), EntropyInjector
+			.resolveEntropy(path, efs, false));
+	}
+
+	@Test
+	public void testCreateEntropyAwarePlainFs() throws Exception {
+		File folder = TMP_FOLDER.newFolder();
+		Path path = new Path(Path.fromLocalFile(folder), "_entropy_/file");
+
+		OutputStreamAndPath out = EntropyInjector.createEntropyAware(
+				LocalFileSystem.getSharedInstance(), path, WriteMode.NO_OVERWRITE);
+
+		out.stream().close();
+
+		assertEquals(path, out.path());
+		assertTrue(new File (new File(folder, "_entropy_"), "file").exists());
+	}
+
+	@Test
+	public void testCreateEntropyAwareEntropyFs() throws Exception {
+		File folder = TMP_FOLDER.newFolder();
+		Path path = new Path(Path.fromLocalFile(folder), "_entropy_/file");
+		Path pathWithEntropy = new Path(Path.fromLocalFile(folder), "test-entropy/file");
+
+		FileSystem fs = new TestEntropyInjectingFs("_entropy_", "test-entropy");
+
+		OutputStreamAndPath out = EntropyInjector.createEntropyAware(fs, path, WriteMode.NO_OVERWRITE);
+
+		out.stream().close();
+
+		assertEquals(new Path(Path.fromLocalFile(folder), "test-entropy/file"), out.path());
+		assertTrue(new File (new File(folder, "test-entropy"), "file").exists());
+	}
+
+	@Test
+	public void testWithSafetyNet() throws Exception {
+		final String entropyKey = "__ekey__";
+		final String entropyValue = "abc";
+
+		final File folder = TMP_FOLDER.newFolder();
+
+		final Path path = new Path(Path.fromLocalFile(folder), entropyKey + "/path/");
+		final Path pathWithEntropy = new Path(Path.fromLocalFile(folder), entropyValue + "/path/");
+
+		TestEntropyInjectingFs efs = new TestEntropyInjectingFs(entropyKey, entropyValue);
+
+		FSDataOutputStream out;
+
+		FileSystemSafetyNet.initializeSafetyNetForThread();
+		FileSystem fs = FileSystemSafetyNet.wrapWithSafetyNetWhenActivated(efs);
+		try  {
+			OutputStreamAndPath streamAndPath = EntropyInjector.createEntropyAware(
+					fs, path, WriteMode.NO_OVERWRITE);
+
+			out = streamAndPath.stream();
+
+			assertEquals(pathWithEntropy, streamAndPath.path());
+		}
+		finally {
+			FileSystemSafetyNet.closeSafetyNetAndGuardedResourcesForThread();
+		}
+
+		// check that the safety net closed the stream
+		try {
+			out.write(42);
+			out.flush();
+			fail("stream should be already close and hence fail with an exception");
+		} catch (IOException ignored) {}
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static final class TestEntropyInjectingFs extends LocalFileSystem implements
+		EntropyInjectingFileSystem {
+
+		private final String key;
+
+		private final String entropy;
+
+		TestEntropyInjectingFs(String key, String entropy) {
+			this.key = key;
+			this.entropy = entropy;
+		}
+
+		@Override
+		public String getEntropyInjectionKey() {
+			return key;
+		}
+
+		@Override
+		public String generateEntropy() {
+			return entropy;
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/core/fs/LimitedConnectionsFileSystemDelegationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/LimitedConnectionsFileSystemDelegationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.core.fs;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 
 import org.junit.Rule;
@@ -56,7 +57,7 @@ public class LimitedConnectionsFileSystemDelegationTest {
 		when(fs.create(any(Path.class), any(WriteMode.class))).thenReturn(mock(FSDataOutputStream.class));
 		when(fs.create(any(Path.class), anyBoolean(), anyInt(), anyShort(), anyLong())).thenReturn(mock(FSDataOutputStream.class));
 
-		final LimitedConnectionsFileSystem lfs = new LimitedConnectionsFileSystem(fs, 1000);
+		final LimitedConnectionsFileSystem lfs = new LimitedConnectionsFileSystem(fs, 1000, new Configuration());
 		final Random rnd = new Random();
 
 		lfs.isDistributedFS();
@@ -170,7 +171,7 @@ public class LimitedConnectionsFileSystemDelegationTest {
 		final FileSystem fs = mock(FileSystem.class);
 		when(fs.create(any(Path.class), any(WriteMode.class))).thenReturn(mockOut);
 
-		final LimitedConnectionsFileSystem lfs = new LimitedConnectionsFileSystem(fs, 100);
+		final LimitedConnectionsFileSystem lfs = new LimitedConnectionsFileSystem(fs, 100, new Configuration());
 		final FSDataOutputStream out = lfs.create(mock(Path.class), WriteMode.OVERWRITE);
 
 		// validate the output stream
@@ -214,7 +215,7 @@ public class LimitedConnectionsFileSystemDelegationTest {
 		final FileSystem fs = mock(FileSystem.class);
 		when(fs.open(any(Path.class))).thenReturn(mockIn);
 
-		final LimitedConnectionsFileSystem lfs = new LimitedConnectionsFileSystem(fs, 100);
+		final LimitedConnectionsFileSystem lfs = new LimitedConnectionsFileSystem(fs, 100, new Configuration());
 		final FSDataInputStream in = lfs.open(mock(Path.class));
 
 		// validate the input stream

--- a/flink-core/src/test/java/org/apache/flink/core/fs/LimitedConnectionsFileSystemTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/LimitedConnectionsFileSystemTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.core.fs;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.core.testutils.CheckedThread;
@@ -52,7 +53,8 @@ public class LimitedConnectionsFileSystemTest {
 				Integer.MAX_VALUE,  // limited outgoing
 				Integer.MAX_VALUE,  // unlimited incoming
 				Long.MAX_VALUE - 1, // long timeout, close to overflow
-				Long.MAX_VALUE - 1); // long timeout, close to overflow
+				Long.MAX_VALUE - 1,
+				new Configuration()); // long timeout, close to overflow
 
 		assertEquals(Integer.MAX_VALUE, limitedFs.getMaxNumOpenStreamsTotal());
 		assertEquals(Integer.MAX_VALUE, limitedFs.getMaxNumOpenOutputStreams());
@@ -73,7 +75,8 @@ public class LimitedConnectionsFileSystemTest {
 				maxConcurrentOpen,  // limited outgoing
 				Integer.MAX_VALUE,  // unlimited incoming
 				0,
-				0);
+				0,
+				new Configuration());
 
 		final WriterThread[] threads = new WriterThread[numThreads];
 		for (int i = 0; i < numThreads; i++) {
@@ -101,7 +104,8 @@ public class LimitedConnectionsFileSystemTest {
 				Integer.MAX_VALUE,  // unlimited outgoing
 				maxConcurrentOpen,  // limited incoming
 				0,
-				0);
+				0,
+				new Configuration());
 
 		final Random rnd = new Random();
 
@@ -129,7 +133,8 @@ public class LimitedConnectionsFileSystemTest {
 
 		final LimitedConnectionsFileSystem limitedFs = new LimitedConnectionsFileSystem(
 				LocalFileSystem.getSharedInstance(),
-				maxConcurrentOpen);  // limited total
+				maxConcurrentOpen,
+				new Configuration());  // limited total
 
 		final Random rnd = new Random();
 
@@ -166,7 +171,8 @@ public class LimitedConnectionsFileSystemTest {
 				LocalFileSystem.getSharedInstance(),
 				maxConcurrentOpen, // limited total
 				openTimeout,       // small opening timeout
-				0L);               // infinite inactivity timeout
+				0L,
+				new Configuration());               // infinite inactivity timeout
 
 		// create the threads that block all streams
 		final BlockingWriterThread[] threads = new BlockingWriterThread[maxConcurrentOpen];
@@ -206,7 +212,8 @@ public class LimitedConnectionsFileSystemTest {
 				LocalFileSystem.getSharedInstance(),
 				maxConcurrentOpen, // limited total
 				openTimeout,       // small opening timeout
-				0L);               // infinite inactivity timeout
+				0L,
+				new Configuration());               // infinite inactivity timeout
 
 		// create the threads that block all streams
 		final Random rnd = new Random();
@@ -254,7 +261,8 @@ public class LimitedConnectionsFileSystemTest {
 				maxConcurrentOpen,  // limit on output streams
 				Integer.MAX_VALUE,  // no limit on input streams
 				0,
-				50);               // timeout of 50 ms
+				50, // timeout of 50 ms
+				new Configuration());
 
 		final WriterThread[] threads = new WriterThread[numThreads];
 		final BlockingWriterThread[] blockers = new BlockingWriterThread[numThreads];
@@ -309,7 +317,8 @@ public class LimitedConnectionsFileSystemTest {
 				Integer.MAX_VALUE,  // limit on output streams
 				maxConcurrentOpen,  // no limit on input streams
 				0,
-				50);               // timeout of 50 ms
+				50,
+				new Configuration());               // timeout of 50 ms
 
 		final Random rnd = new Random();
 
@@ -369,7 +378,8 @@ public class LimitedConnectionsFileSystemTest {
 				LocalFileSystem.getSharedInstance(),
 				maxConcurrentOpen,  // limited total
 				0L,                 // no opening timeout
-				50L);               // inactivity timeout of 50 ms
+				50L,
+				new Configuration());               // inactivity timeout of 50 ms
 
 		final Random rnd = new Random();
 
@@ -426,7 +436,7 @@ public class LimitedConnectionsFileSystemTest {
 
 	@Test
 	public void testFailingStreamsUnregister() throws Exception {
-		final LimitedConnectionsFileSystem fs = new LimitedConnectionsFileSystem(new FailFs(), 1);
+		final LimitedConnectionsFileSystem fs = new LimitedConnectionsFileSystem(new FailFs(), 1, new Configuration());
 
 		assertEquals(0, fs.getNumberOfOpenInputStreams());
 		assertEquals(0, fs.getNumberOfOpenOutputStreams());
@@ -458,7 +468,7 @@ public class LimitedConnectionsFileSystemTest {
 	@Test
 	public void testSlowOutputStreamNotClosed() throws Exception {
 		final LimitedConnectionsFileSystem fs = new LimitedConnectionsFileSystem(
-				LocalFileSystem.getSharedInstance(), 1, 0L, 1000L);
+				LocalFileSystem.getSharedInstance(), 1, 0L, 1000L, new Configuration());
 
 		// some competing threads
 		final Random rnd = new Random();
@@ -502,7 +512,7 @@ public class LimitedConnectionsFileSystemTest {
 		createRandomContents(file, new Random(), 50);
 
 		final LimitedConnectionsFileSystem fs = new LimitedConnectionsFileSystem(
-				LocalFileSystem.getSharedInstance(), 1, 0L, 1000L);
+				LocalFileSystem.getSharedInstance(), 1, 0L, 1000L, new Configuration());
 
 		// some competing threads
 		final WriterThread[] threads = new WriterThread[10];

--- a/flink-core/src/test/java/org/apache/flink/util/StringUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/StringUtilsTest.java
@@ -22,6 +22,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Random;
 
 /**
  * Tests for the {@link StringUtils}.
@@ -56,4 +59,14 @@ public class StringUtilsTest extends TestLogger {
 		String hex = StringUtils.byteToHexString(byteArray);
 		assertEquals("019f314a", hex);
 	}
+
+	@Test
+	public void testGenerateAlphanumeric() {
+		String str = StringUtils.generateRandomAlphanumericString(new Random(), 256);
+
+		if (!str.matches("[a-zA-Z0-9]{256}")) {
+			fail("Not alphanumeric: " + str);
+		}
+	}
+
 }

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.fs.hdfs;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.AbstractEntropyInjectingFileSystemBase;
 import org.apache.flink.core.fs.BlockLocation;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
@@ -33,7 +35,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * A {@link FileSystem} that wraps an {@link org.apache.hadoop.fs.FileSystem Hadoop File System}.
  */
-public class HadoopFileSystem extends FileSystem {
+public class HadoopFileSystem extends AbstractEntropyInjectingFileSystemBase {
 
 	/** The wrapped Hadoop File System. */
 	private final org.apache.hadoop.fs.FileSystem fs;
@@ -49,7 +51,8 @@ public class HadoopFileSystem extends FileSystem {
 	 *
 	 * @param hadoopFileSystem The Hadoop FileSystem that will be used under the hood.
 	 */
-	public HadoopFileSystem(org.apache.hadoop.fs.FileSystem hadoopFileSystem) {
+	public HadoopFileSystem(org.apache.hadoop.fs.FileSystem hadoopFileSystem, Configuration flinkConfig) {
+		super(flinkConfig);
 		this.fs = checkNotNull(hadoopFileSystem, "hadoopFileSystem");
 	}
 

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
@@ -48,7 +48,7 @@ public class HadoopFsFactory implements FileSystemFactory {
 	private static final Logger LOG = LoggerFactory.getLogger(HadoopFsFactory.class);
 
 	/** Flink's configuration object. */
-	private Configuration flinkConfig;
+	protected Configuration flinkConfig;
 
 	/** Hadoop's configuration for the file systems. */
 	private org.apache.hadoop.conf.Configuration hadoopConfig;
@@ -165,7 +165,7 @@ public class HadoopFsFactory implements FileSystemFactory {
 				throw new IOException(message, e);
 			}
 
-			HadoopFileSystem fs = new HadoopFileSystem(hadoopFs);
+			HadoopFileSystem fs = new HadoopFileSystem(hadoopFs, flinkConfig);
 
 			// create the Flink file system, optionally limiting the open connections
 			if (flinkConfig != null) {
@@ -209,7 +209,8 @@ public class HadoopFsFactory implements FileSystemFactory {
 					limitSettings.limitOutput,
 					limitSettings.limitInput,
 					limitSettings.streamOpenTimeout,
-					limitSettings.streamInactivityTimeout);
+					limitSettings.streamInactivityTimeout,
+					config);
 		}
 	}
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopLocalFileSystemBehaviorTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopLocalFileSystemBehaviorTest.java
@@ -43,7 +43,7 @@ public class HadoopLocalFileSystemBehaviorTest extends FileSystemBehaviorTestSui
 	public FileSystem getFileSystem() throws Exception {
 		org.apache.hadoop.fs.FileSystem fs = new RawLocalFileSystem();
 		fs.initialize(LocalFileSystem.getLocalFsURI(), new Configuration());
-		return new HadoopFileSystem(fs);
+		return new HadoopFileSystem(fs, new org.apache.flink.configuration.Configuration());
 	}
 
 	@Override

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HdfsBehaviorTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HdfsBehaviorTest.java
@@ -65,7 +65,7 @@ public class HdfsBehaviorTest extends FileSystemBehaviorTestSuite {
 		hdfsCluster = builder.build();
 
 		org.apache.hadoop.fs.FileSystem hdfs = hdfsCluster.getFileSystem();
-		fs = new HadoopFileSystem(hdfs);
+		fs = new HadoopFileSystem(hdfs, new org.apache.flink.configuration.Configuration());
 
 		basePath = new Path(hdfs.getUri().toString() + "/tests");
 	}

--- a/flink-filesystems/flink-mapr-fs/src/main/java/org/apache/flink/runtime/fs/maprfs/MapRFileSystem.java
+++ b/flink-filesystems/flink-mapr-fs/src/main/java/org/apache/flink/runtime/fs/maprfs/MapRFileSystem.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.fs.maprfs;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystemKind;
 import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
 
@@ -63,8 +64,8 @@ public class MapRFileSystem extends HadoopFileSystem {
 	 * @param fsUri The URI describing the file system
 	 * @throws IOException Thrown if the file system could not be initialized.
 	 */
-	public MapRFileSystem(URI fsUri) throws IOException {
-		super(instantiateMapRFileSystem(fsUri));
+	public MapRFileSystem(URI fsUri, Configuration flinkConfig) throws IOException {
+		super(instantiateMapRFileSystem(fsUri), flinkConfig);
 	}
 
 	private static org.apache.hadoop.fs.FileSystem instantiateMapRFileSystem(URI fsUri) throws IOException {

--- a/flink-filesystems/flink-mapr-fs/src/main/java/org/apache/flink/runtime/fs/maprfs/MapRFsFactory.java
+++ b/flink-filesystems/flink-mapr-fs/src/main/java/org/apache/flink/runtime/fs/maprfs/MapRFsFactory.java
@@ -39,6 +39,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class MapRFsFactory implements FileSystemFactory {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MapRFsFactory.class);
+	private Configuration flinkConfig;
 
 	// ------------------------------------------------------------------------
 
@@ -50,6 +51,7 @@ public class MapRFsFactory implements FileSystemFactory {
 	@Override
 	public void configure(Configuration config) {
 		// nothing to configure based on the configuration here
+		this.flinkConfig = config;
 	}
 
 	@Override
@@ -59,7 +61,7 @@ public class MapRFsFactory implements FileSystemFactory {
 		try {
 			LOG.info("Trying to load and instantiate MapR File System");
 
-			return new MapRFileSystem(fsUri);
+			return new MapRFileSystem(fsUri, flinkConfig);
 		}
 		catch (LinkageError e) {
 			throw new IOException("Could not load MapR file system. "  +

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
@@ -132,7 +132,7 @@ public class S3FileSystemFactory implements FileSystemFactory {
 			final S3AFileSystem fs = new S3AFileSystem();
 			fs.initialize(fsUri, hadoopConfig);
 
-			return new HadoopFileSystem(fs);
+			return new HadoopFileSystem(fs, flinkConfig);
 		}
 		catch (IOException e) {
 			throw e;

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
@@ -131,7 +131,7 @@ public class S3FileSystemFactory implements FileSystemFactory {
 			final PrestoS3FileSystem fs = new PrestoS3FileSystem();
 			fs.initialize(initUri, hadoopConfig);
 
-			return new HadoopFileSystem(fs);
+			return new HadoopFileSystem(fs, flinkConfig);
 		}
 		catch (IOException e) {
 			throw e;

--- a/flink-filesystems/flink-swift-fs-hadoop/src/main/java/org/apache/flink/fs/openstackhadoop/SwiftFileSystemFactory.java
+++ b/flink-filesystems/flink-swift-fs-hadoop/src/main/java/org/apache/flink/fs/openstackhadoop/SwiftFileSystemFactory.java
@@ -123,7 +123,7 @@ public class SwiftFileSystemFactory implements FileSystemFactory {
 			final SwiftNativeFileSystem fs = new SwiftNativeFileSystem();
 			fs.initialize(fsUri, hadoopConfig);
 
-			return new HadoopFileSystem(fs);
+			return new HadoopFileSystem(fs, flinkConfig);
 		}
 		catch (IOException e) {
 			throw e;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointMetadataOutputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointMetadataOutputStream.java
@@ -133,7 +133,7 @@ public final class FsCheckpointMetadataOutputStream extends CheckpointMetadataOu
 					FileStateHandle metaDataHandle = new FileStateHandle(metadataFilePath, size);
 
 					return new FsCompletedCheckpointStorageLocation(
-							fileSystem, exclusiveCheckpointDir, metaDataHandle, exclusiveCheckpointDir.toString());
+							fileSystem, exclusiveCheckpointDir, metaDataHandle, metaDataHandle.getFilePath().getParent().toString());
 				}
 				catch (Exception e) {
 					try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorage.java
@@ -49,6 +49,20 @@ public class FsCheckpointStorage extends AbstractFsCheckpointStorage {
 	private final int fileSizeThreshold;
 
 	public FsCheckpointStorage(
+		Path checkpointBaseDirectory,
+		@Nullable Path defaultSavepointDirectory,
+		JobID jobId,
+		int fileSizeThreshold) throws IOException {
+
+		this(checkpointBaseDirectory.getFileSystem(),
+			checkpointBaseDirectory,
+			defaultSavepointDirectory,
+			jobId,
+			fileSizeThreshold);
+	}
+
+	public FsCheckpointStorage(
+			FileSystem fs,
 			Path checkpointBaseDirectory,
 			@Nullable Path defaultSavepointDirectory,
 			JobID jobId,
@@ -58,7 +72,7 @@ public class FsCheckpointStorage extends AbstractFsCheckpointStorage {
 
 		checkArgument(fileSizeThreshold >= 0);
 
-		this.fileSystem = checkpointBaseDirectory.getFileSystem();
+		this.fileSystem = fs;
 		this.checkpointsDirectory = getCheckpointDirectoryForJob(checkpointBaseDirectory, jobId);
 		this.sharedStateDirectory = new Path(checkpointsDirectory, CHECKPOINT_SHARED_STATE_DIR);
 		this.taskOwnedStateDirectory = new Path(checkpointsDirectory, CHECKPOINT_TASK_OWNED_STATE_DIR);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state.filesystem;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.fs.EntropyInjector;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
@@ -67,7 +68,10 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory imple
 		this.taskOwnedStateDirectory = checkNotNull(taskOwnedStateDir);
 		this.reference = checkNotNull(reference);
 
-		this.metadataFilePath = new Path(checkpointDir, AbstractFsCheckpointStorage.METADATA_FILE_NAME);
+		// the metadata file should not have entropy in its path
+		Path metadataDir = EntropyInjector.removeEntropyMarkerIfPresent(fileSystem, checkpointDir);
+
+		this.metadataFilePath = new Path(metadataDir, AbstractFsCheckpointStorage.METADATA_FILE_NAME);
 		this.fileStateSizeThreshold = fileStateSizeThreshold;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -18,8 +18,11 @@
 
 package org.apache.flink.runtime.state.filesystem;
 
+import org.apache.flink.core.fs.EntropyInjector;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystem.WriteMode;
+import org.apache.flink.core.fs.OutputStreamAndPath;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
@@ -344,12 +347,10 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 			Exception latestException = null;
 			for (int attempt = 0; attempt < 10; attempt++) {
 				try {
-					Path statePath = createStatePath();
-					FSDataOutputStream outStream = fs.create(statePath, FileSystem.WriteMode.NO_OVERWRITE);
-
-					// success, managed to open the stream
-					this.statePath = statePath;
-					this.outStream = outStream;
+					OutputStreamAndPath streamAndPath = EntropyInjector.createEntropyAware(
+						fs, createStatePath(), WriteMode.NO_OVERWRITE);
+					this.outStream = streamAndPath.stream();
+					this.statePath = streamAndPath.path();
 					return;
 				}
 				catch (Exception e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsStateBackendEntropyTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.EntropyInjectingFileSystem;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
+import org.apache.flink.runtime.state.CheckpointStreamFactory.CheckpointStateOutputStream;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests verifying that the FsStateBackend passes the entropy injection option
+ * to the FileSystem for state payload files, but not for metadata files.
+ */
+public class FsStateBackendEntropyTest {
+
+	static final String ENTROPY_MARKER = "__ENTROPY__";
+	static final String RESOLVED_MARKER = "+RESOLVED+";
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	@Test
+	public void testEntropyInjection() throws Exception {
+		final FileSystem fs = new TestEntropyAwareFs();
+
+		final Path checkpointDir = new Path(Path.fromLocalFile(tmp.newFolder()), ENTROPY_MARKER + "/checkpoints");
+		final String checkpointDirStr = checkpointDir.toString();
+
+		FsCheckpointStorage storage = new FsCheckpointStorage(fs, checkpointDir, null, new JobID(), 1024);
+
+		FsCheckpointStorageLocation location = (FsCheckpointStorageLocation)
+				storage.initializeLocationForCheckpoint(96562);
+
+		assertThat(location.getCheckpointDirectory().toString(), startsWith(checkpointDirStr));
+		assertThat(location.getSharedStateDirectory().toString(), startsWith(checkpointDirStr));
+		assertThat(location.getTaskOwnedStateDirectory().toString(), startsWith(checkpointDirStr));
+		assertThat(location.getMetadataFilePath().toString(), not(containsString(ENTROPY_MARKER)));
+
+		// check entropy in task-owned state
+		try (CheckpointStateOutputStream stream = storage.createTaskOwnedStateStream()) {
+			stream.flush();
+			FileStateHandle handle = (FileStateHandle) stream.closeAndGetHandle();
+
+			assertNotNull(handle);
+			assertThat(handle.getFilePath().toString(), not(containsString(ENTROPY_MARKER)));
+			assertThat(handle.getFilePath().toString(), containsString(RESOLVED_MARKER));
+		}
+
+		// check entropy in the exclusive/shared state
+		try (CheckpointStateOutputStream stream =
+				location.createCheckpointStateOutputStream(CheckpointedStateScope.EXCLUSIVE)) {
+
+			stream.flush();
+			FileStateHandle handle = (FileStateHandle) stream.closeAndGetHandle();
+
+			assertNotNull(handle);
+			assertThat(handle.getFilePath().toString(), not(containsString(ENTROPY_MARKER)));
+			assertThat(handle.getFilePath().toString(), containsString(RESOLVED_MARKER));
+		}
+
+		// check that there is no entropy in the metadata
+		// check entropy in the exclusive/shared state
+		try (CheckpointMetadataOutputStream stream = location.createMetadataOutputStream()) {
+			stream.flush();
+			FsCompletedCheckpointStorageLocation handle =
+					(FsCompletedCheckpointStorageLocation) stream.closeAndFinalizeCheckpoint();
+
+			assertNotNull(handle);
+
+			// metadata files have no entropy
+			assertThat(handle.getMetadataHandle().getFilePath().toString(), not(containsString(ENTROPY_MARKER)));
+			assertThat(handle.getMetadataHandle().getFilePath().toString(), not(containsString(RESOLVED_MARKER)));
+
+			// external location is the same as metadata, without the file name
+			assertEquals(handle.getMetadataHandle().getFilePath().getParent().toString(), handle.getExternalPointer());
+		}
+	}
+
+	private static class TestEntropyAwareFs extends LocalFileSystem implements
+		EntropyInjectingFileSystem {
+
+		@Override
+		public String getEntropyInjectionKey() {
+			return ENTROPY_MARKER;
+		}
+
+		@Override
+		public String generateEntropy() {
+			return RESOLVED_MARKER;
+		}
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/highavailability/YarnHighAvailabilityServices.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/highavailability/YarnHighAvailabilityServices.java
@@ -142,7 +142,7 @@ public abstract class YarnHighAvailabilityServices implements HighAvailabilitySe
 			throw new IOException("Cannot instantiate YARN's Hadoop file system for " + fsUri, e);
 		}
 
-		this.flinkFileSystem = new HadoopFileSystem(hadoopFileSystem);
+		this.flinkFileSystem = new HadoopFileSystem(hadoopFileSystem, config);
 
 		this.workingDirectory = new Path(hadoopFileSystem.getWorkingDirectory().toUri());
 		this.haDataDirectory = new Path(workingDirectory, FLINK_RECOVERY_DATA_DIR);


### PR DESCRIPTION
This has been done in Flink 1.6+ but those changes are not fully compatible w/ Flink 1.5 and only work with the bundled FileSystems.  We don't use those at Lyft so this took a bit of refactoring.
