### PR TITLE
[FLINK-11617] [kinesis] Kinesis consumer getRecords() failure logging is misleading.

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -222,7 +222,7 @@ public class KinesisProxy implements KinesisProxyInterface {
 					long backoffMillis = fullJitterBackoff(
 						getRecordsBaseBackoffMillis, getRecordsMaxBackoffMillis, getRecordsExpConstant, attempt++);
 					LOG.warn("Got recoverable SdkClientException. Backing off for "
-						+ backoffMillis + " millis (" + ex.getMessage() + ")");
+						+ backoffMillis + " millis (" + ex.getClass().getName() + ": " + ex.getMessage() + ")");
 					Thread.sleep(backoffMillis);
 				} else {
 					throw ex;
@@ -231,8 +231,8 @@ public class KinesisProxy implements KinesisProxyInterface {
 		}
 
 		if (getRecordsResult == null) {
-			throw new RuntimeException("Rate Exceeded for getRecords operation - all " + getRecordsMaxAttempts +
-				" retry attempts returned ProvisionedThroughputExceededException.");
+			throw new RuntimeException("Retries exceeded for getRecords operation - all " + getRecordsMaxAttempts +
+				" retry attempts failed.");
 		}
 
 		return getRecordsResult;
@@ -297,7 +297,7 @@ public class KinesisProxy implements KinesisProxyInterface {
 					long backoffMillis = fullJitterBackoff(
 						getShardIteratorBaseBackoffMillis, getShardIteratorMaxBackoffMillis, getShardIteratorExpConstant, attempt++);
 					LOG.warn("Got recoverable AmazonServiceException. Backing off for "
-						+ backoffMillis + " millis (" + ex.getErrorMessage() + ")");
+						+ backoffMillis + " millis (" + ex.getClass().getName() + ": " + ex.getMessage() + ")");
 					Thread.sleep(backoffMillis);
 				} else {
 					throw ex;
@@ -306,8 +306,8 @@ public class KinesisProxy implements KinesisProxyInterface {
 		}
 
 		if (getShardIteratorResult == null) {
-			throw new RuntimeException("Rate Exceeded for getShardIterator operation - all " + getShardIteratorMaxAttempts +
-				" retry attempts returned ProvisionedThroughputExceededException.");
+			throw new RuntimeException("Retries exceeded for getShardIterator operation - all " + getShardIteratorMaxAttempts +
+				" retry attempts failed.");
 		}
 		return getShardIteratorResult.getShardIterator();
 	}


### PR DESCRIPTION
Cherry pick 91a53838b60cd77cfef40f16cce8324c5c24ca82.
