### PR TITLE
FLINK-13864: Modify the StreamingFileSink Builder interface to allow for easier subclassing of StreamingFileSink

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -96,6 +96,8 @@ public class StreamingFileSink<IN>
 		extends RichSinkFunction<IN>
 		implements CheckpointedFunction, CheckpointListener, ProcessingTimeCallback {
 
+	private static final long DEFAULT_BUCKET_CHECK_INTERVAL = 60L * 1000L;
+
 	private static final long serialVersionUID = 1L;
 
 	// -------------------------- state descriptors ---------------------------
@@ -110,7 +112,7 @@ public class StreamingFileSink<IN>
 
 	private final long bucketCheckInterval;
 
-	private final StreamingFileSink.BucketsBuilder<IN, ?> bucketsBuilder;
+	private final StreamingFileSink.BucketsBuilder<IN, ?, ?> bucketsBuilder;
 
 	// --------------------------- runtime fields -----------------------------
 
@@ -128,7 +130,7 @@ public class StreamingFileSink<IN>
 	 * Creates a new {@code StreamingFileSink} that writes files to the given base directory.
 	 */
 	protected StreamingFileSink(
-			final StreamingFileSink.BucketsBuilder<IN, ?> bucketsBuilder,
+			final StreamingFileSink.BucketsBuilder<IN, ?, ?> bucketsBuilder,
 			final long bucketCheckInterval) {
 
 		Preconditions.checkArgument(bucketCheckInterval > 0L);
@@ -149,8 +151,8 @@ public class StreamingFileSink<IN>
 	 * @return The builder where the remaining of the configuration parameters for the sink can be configured.
 	 * In order to instantiate the sink, call {@link RowFormatBuilder#build()} after specifying the desired parameters.
 	 */
-	public static <IN> StreamingFileSink.RowFormatBuilder<IN, String> forRowFormat(
-			final Path basePath, final Encoder<IN> encoder) {
+	public static <IN> StreamingFileSink.RowFormatBuilder<IN, String, ? extends RowFormatBuilder<IN, String, ?>>
+		forRowFormat(final Path basePath, final Encoder<IN> encoder) {
 		return new StreamingFileSink.RowFormatBuilder<>(basePath, encoder, new DateTimeBucketAssigner<>());
 	}
 
@@ -162,17 +164,23 @@ public class StreamingFileSink<IN>
 	 * @return The builder where the remaining of the configuration parameters for the sink can be configured.
 	 * In order to instantiate the sink, call {@link RowFormatBuilder#build()} after specifying the desired parameters.
 	 */
-	public static <IN> StreamingFileSink.BulkFormatBuilder<IN, String> forBulkFormat(
-			final Path basePath, final BulkWriter.Factory<IN> writerFactory) {
+	public static <IN> StreamingFileSink.BulkFormatBuilder<IN, String, ? extends BulkFormatBuilder<IN, String, ?>>
+		forBulkFormat(final Path basePath, final BulkWriter.Factory<IN> writerFactory) {
 		return new StreamingFileSink.BulkFormatBuilder<>(basePath, writerFactory, new DateTimeBucketAssigner<>());
 	}
 
 	/**
 	 * The base abstract class for the {@link RowFormatBuilder} and {@link BulkFormatBuilder}.
 	 */
-	protected abstract static class BucketsBuilder<IN, BucketID> implements Serializable {
+	protected abstract static class BucketsBuilder<IN, BucketID, T extends BucketsBuilder<IN, BucketID, T>> implements
+		Serializable {
 
 		private static final long serialVersionUID = 1L;
+
+		@SuppressWarnings("unchecked")
+		protected T self() {
+			return (T) this;
+		}
 
 		abstract Buckets<IN, BucketID> createBuckets(final int subtaskIndex) throws IOException;
 	}
@@ -181,24 +189,26 @@ public class StreamingFileSink<IN>
 	 * A builder for configuring the sink for row-wise encoding formats.
 	 */
 	@PublicEvolving
-	public static class RowFormatBuilder<IN, BucketID> extends StreamingFileSink.BucketsBuilder<IN, BucketID> {
+	public static class RowFormatBuilder<IN, BucketID, T extends RowFormatBuilder<IN, BucketID, T>> extends
+		StreamingFileSink.BucketsBuilder<IN, BucketID, T> {
 
 		private static final long serialVersionUID = 1L;
 
-		private final long bucketCheckInterval;
+		protected long bucketCheckInterval;
 
 		private final Path basePath;
 
-		private final Encoder<IN> encoder;
+		private Encoder<IN> encoder;
 
-		private final BucketAssigner<IN, BucketID> bucketAssigner;
+		private BucketAssigner<IN, BucketID> bucketAssigner;
 
-		private final RollingPolicy<IN, BucketID> rollingPolicy;
+		private RollingPolicy<IN, BucketID> rollingPolicy;
 
-		private final BucketFactory<IN, BucketID> bucketFactory;
+		private BucketFactory<IN, BucketID> bucketFactory;
 
 		RowFormatBuilder(Path basePath, Encoder<IN> encoder, BucketAssigner<IN, BucketID> bucketAssigner) {
-			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.create().build(), 60L * 1000L, new DefaultBucketFactoryImpl<>());
+			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.create().build(),
+				DEFAULT_BUCKET_CHECK_INTERVAL, new DefaultBucketFactoryImpl<>());
 		}
 
 		private RowFormatBuilder(
@@ -216,20 +226,32 @@ public class StreamingFileSink<IN>
 			this.bucketFactory = Preconditions.checkNotNull(bucketFactory);
 		}
 
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketCheckInterval(final long interval) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, interval, bucketFactory);
+		public T withBucketCheckInterval(final long interval) {
+			this.bucketCheckInterval = interval;
+			return self();
 		}
 
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketAssigner(final BucketAssigner<IN, BucketID> assigner) {
-			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), rollingPolicy, bucketCheckInterval, bucketFactory);
+		public T withBucketAssigner(final BucketAssigner<IN, BucketID> assigner) {
+			this.bucketAssigner = Preconditions.checkNotNull(assigner);
+			return self();
 		}
 
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withRollingPolicy(final RollingPolicy<IN, BucketID> policy) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, Preconditions.checkNotNull(policy), bucketCheckInterval, bucketFactory);
+		public T withRollingPolicy(final RollingPolicy<IN, BucketID> policy) {
+			this.rollingPolicy = Preconditions.checkNotNull(policy);
+			return self();
 		}
 
-		public <ID> StreamingFileSink.RowFormatBuilder<IN, ID> withBucketAssignerAndPolicy(final BucketAssigner<IN, ID> assigner, final RollingPolicy<IN, ID> policy) {
-			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), Preconditions.checkNotNull(policy), bucketCheckInterval, new DefaultBucketFactoryImpl<>());
+		public T withBucketAssignerAndPolicy(final BucketAssigner<IN, BucketID> assigner, final RollingPolicy<IN,
+			BucketID> policy) {
+			this.bucketAssigner = Preconditions.checkNotNull(assigner);
+			this.rollingPolicy = Preconditions.checkNotNull(policy);
+			return self();
+		}
+
+		@VisibleForTesting
+		T withBucketFactory(final BucketFactory<IN, BucketID> factory) {
+			this.bucketFactory = Preconditions.checkNotNull(factory);
+			return self();
 		}
 
 		/** Creates the actual sink. */
@@ -247,34 +269,30 @@ public class StreamingFileSink<IN>
 					rollingPolicy,
 					subtaskIndex);
 		}
-
-		@VisibleForTesting
-		StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketFactory(final BucketFactory<IN, BucketID> factory) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, Preconditions.checkNotNull(factory));
-		}
 	}
 
 	/**
 	 * A builder for configuring the sink for bulk-encoding formats, e.g. Parquet/ORC.
 	 */
 	@PublicEvolving
-	public static class BulkFormatBuilder<IN, BucketID> extends StreamingFileSink.BucketsBuilder<IN, BucketID> {
+	public static class BulkFormatBuilder<IN, BucketID, T extends BulkFormatBuilder<IN, BucketID, T>> extends
+		StreamingFileSink.BucketsBuilder<IN, BucketID, T> {
 
 		private static final long serialVersionUID = 1L;
 
-		protected final long bucketCheckInterval;
+		private final Path basePath;
 
-		protected final Path basePath;
+		protected long bucketCheckInterval;
 
-		protected final BulkWriter.Factory<IN> writerFactory;
+		private BulkWriter.Factory<IN> writerFactory;
 
-		protected final BucketAssigner<IN, BucketID> bucketAssigner;
+		private BucketAssigner<IN, BucketID> bucketAssigner;
 
-		protected final BucketFactory<IN, BucketID> bucketFactory;
+		private BucketFactory<IN, BucketID> bucketFactory;
 
 		public BulkFormatBuilder(Path basePath, BulkWriter.Factory<IN> writerFactory,
 						   BucketAssigner<IN, BucketID> assigner) {
-			this(basePath, writerFactory, assigner, 60L * 1000L, new DefaultBucketFactoryImpl<>());
+			this(basePath, writerFactory, assigner, DEFAULT_BUCKET_CHECK_INTERVAL, new DefaultBucketFactoryImpl<>());
 		}
 
 		protected BulkFormatBuilder(
@@ -290,17 +308,20 @@ public class StreamingFileSink<IN>
 			this.bucketFactory = Preconditions.checkNotNull(bucketFactory);
 		}
 
-		public StreamingFileSink.BulkFormatBuilder<IN, BucketID> withBucketCheckInterval(long interval) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, interval, bucketFactory);
+		public T withBucketCheckInterval(long interval) {
+			this.bucketCheckInterval = interval;
+			return self();
 		}
 
-		public <ID> StreamingFileSink.BulkFormatBuilder<IN, ID> withBucketAssigner(BucketAssigner<IN, ID> assigner) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, Preconditions.checkNotNull(assigner), bucketCheckInterval, new DefaultBucketFactoryImpl<>());
+		public T withBucketAssigner(BucketAssigner<IN, BucketID> assigner) {
+			this.bucketAssigner = Preconditions.checkNotNull(assigner);
+			return self();
 		}
 
 		@VisibleForTesting
-		StreamingFileSink.BulkFormatBuilder<IN, BucketID> withBucketFactory(final BucketFactory<IN, BucketID> factory) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, Preconditions.checkNotNull(factory));
+		T withBucketFactory(final BucketFactory<IN, BucketID> factory) {
+			this.bucketFactory = Preconditions.checkNotNull(factory);
+			return self();
 		}
 
 		/** Creates the actual sink. */


### PR DESCRIPTION
## What is the purpose of the change

This patch makes it easier to extend `StreamingFileSink`, which adopts the builder pattern as a way to construct a new `StreamingFileSink` object. It follows the technique of "recurring generic pattern" which is documented in [[1](https://community.oracle.com/blogs/emcmanus/2010/10/24/using-builder-pattern-subclasses)] and [[2](https://stackoverflow.com/questions/17164375/subclassing-a-java-builder-class)].  

## Brief change log

**StreamingFileSink**
  - Added the builder type as the class signature for `BucketsBuilder`, `RowFormatBuilder` and `BulkFormatBuilder`. 
  - Added a `self()` method inside `BucketsBuilder` to return the proper builder type for base classes and subclasses in the path of inheritance. 
  - Change the construction methods to return the builder object (`self()`), instead of a new instance of the builder.  
  - Removed `final` for a few variables as they are now set by the construction methods. 

## Verifying this change

This change is merely an interface change and is already covered by existing tests, such as *LocalStreamingFileSinkTest* and *BulkWriterTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (yes) it affects *StreamingFileSink* but merely an interface change.

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

