### PR TITLE
[FLINK-13864][fs-connector] Make StreamingFileSink extensible

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.SharedMetricRegistries;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.Path;
@@ -29,6 +26,9 @@ import org.apache.flink.core.fs.RecoverableWriter;
 import org.apache.flink.core.fs.RecoverableWriter.CommitRecoverable;
 import org.apache.flink.core.fs.RecoverableWriter.ResumeRecoverable;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
-import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.RecoverableWriter;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Buckets.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
-import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.ListState;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkPartWriter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkPartWriter.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
-import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.serialization.BulkWriter;
 import org.apache.flink.core.fs.Path;
@@ -33,7 +32,7 @@ import java.io.IOException;
  * This also implements the {@link PartFileInfo}.
  */
 @PublicEvolving
-final public class BulkPartWriter<IN, BucketID> extends PartFileWriter<IN, BucketID> {
+public final class BulkPartWriter<IN, BucketID> extends PartFileWriter<IN, BucketID> {
 
 	private final BulkWriter<IN> writer;
 
@@ -69,7 +68,7 @@ final public class BulkPartWriter<IN, BucketID> extends PartFileWriter<IN, Bucke
 	 * @param <IN> The type of input elements.
 	 * @param <BucketID> The type of ids for the buckets, as returned by the {@link BucketAssigner}.
 	 */
-	static public class Factory<IN, BucketID> implements PartFileWriter.PartFileFactory<IN,
+	public static class Factory<IN, BucketID> implements PartFileWriter.PartFileFactory<IN,
 		BucketID> {
 
 		private final BulkWriter.Factory<IN> writerFactory;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DefaultBucketFactoryImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/DefaultBucketFactoryImpl.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
-import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.RecoverableWriter;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
@@ -61,43 +61,123 @@ public class BulkWriterTest extends TestLogger {
 								new TestBulkWriterFactory(),
 								new DefaultBucketFactoryImpl<>())
 		) {
-
-			testHarness.setup();
-			testHarness.open();
-
-			// this creates a new bucket "test1" and part-0-0
-			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 1), 1L));
-			TestUtils.checkLocalFs(outDir, 1, 0);
-
-			// we take a checkpoint so we roll.
-			testHarness.snapshot(1L, 1L);
-
-			// these will close part-0-0 and open part-0-1
-			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 2), 2L));
-			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 3), 3L));
-
-			// we take a checkpoint so we roll again.
-			testHarness.snapshot(2L, 2L);
-
-			TestUtils.checkLocalFs(outDir, 2, 0);
-
-			Map<File, String> contents = TestUtils.getFileContentByPath(outDir);
-			int fileCounter = 0;
-			for (Map.Entry<File, String> fileContents : contents.entrySet()) {
-				if (fileContents.getKey().getName().contains(".part-0-0.inprogress")) {
-					fileCounter++;
-					Assert.assertEquals("test1@1\n", fileContents.getValue());
-				} else if (fileContents.getKey().getName().contains(".part-0-1.inprogress")) {
-					fileCounter++;
-					Assert.assertEquals("test1@2\ntest1@3\n", fileContents.getValue());
-				}
-			}
-			Assert.assertEquals(2L, fileCounter);
-
-			// we acknowledge the latest checkpoint, so everything should be published.
-			testHarness.notifyOfCompletedCheckpoint(2L);
-			TestUtils.checkLocalFs(outDir, 0, 2);
+			testPartFilesWithStringBucketer(testHarness, outDir, ".part-0-0.inprogress", ".part-0-1.inprogress");
 		}
+	}
+
+	@Test
+	public void testCustomBulkWriterWithBucketAssigner() throws Exception {
+		final File outDir = TEMP_FOLDER.newFolder();
+
+		// we set the max bucket size to small so that we can know when it rolls
+		try (
+				OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness =
+						TestUtils.createTestSinkWithCustomizedBulkEncoder(
+								outDir,
+								1,
+								0,
+								10L,
+								// use a customized bucketer with Integer bucket ID
+								new TestUtils.TupleToIntegerBucketer(),
+								new TestBulkWriterFactory(),
+								new DefaultBucketFactoryImpl<>())
+		) {
+			testPartFilesWithIntegerBucketer(testHarness, outDir, ".part-0-0.inprogress", ".part-0-1.inprogress", ".part-0-2.inprogress");
+		}
+	}
+
+	private void testPartFilesWithStringBucketer(
+			OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness,
+			File outDir,
+			String partFileName1,
+			String partFileName2) throws Exception {
+
+		testHarness.setup();
+		testHarness.open();
+
+		// this creates a new bucket "test1" and part-0-0
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 1), 1L));
+		TestUtils.checkLocalFs(outDir, 1, 0);
+
+		// we take a checkpoint so we roll.
+		testHarness.snapshot(1L, 1L);
+
+		// these will close part-0-0 and open part-0-1
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 2), 2L));
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 3), 3L));
+
+		// we take a checkpoint so we roll again.
+		testHarness.snapshot(2L, 2L);
+
+		TestUtils.checkLocalFs(outDir, 2, 0);
+
+		Map<File, String> contents = TestUtils.getFileContentByPath(outDir);
+		int fileCounter = 0;
+		for (Map.Entry<File, String> fileContents : contents.entrySet()) {
+			if (fileContents.getKey().getName().contains(".part-0-0.inprogress")) {
+				fileCounter++;
+				Assert.assertEquals("test1@1\n", fileContents.getValue());
+			} else if (fileContents.getKey().getName().contains(".part-0-1.inprogress")) {
+				fileCounter++;
+				Assert.assertEquals("test1@2\ntest1@3\n", fileContents.getValue());
+			}
+		}
+		Assert.assertEquals(2L, fileCounter);
+
+		// we acknowledge the latest checkpoint, so everything should be published.
+		testHarness.notifyOfCompletedCheckpoint(2L);
+		TestUtils.checkLocalFs(outDir, 0, 2);
+	}
+
+	private void testPartFilesWithIntegerBucketer(
+			OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness,
+			File outDir,
+			String partFileName1,
+			String partFileName2,
+			String partFileName3) throws Exception {
+
+		testHarness.setup();
+		testHarness.open();
+
+		// this creates a new bucket "test1" and part-0-0
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 1), 1L));
+		TestUtils.checkLocalFs(outDir, 1, 0);
+
+		// we take a checkpoint so we roll.
+		testHarness.snapshot(1L, 1L);
+
+		// these will close part-0-0 and open part-0-1 and part-0-2
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 2), 2L));
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 3), 3L));
+
+		// we take a checkpoint so we roll again.
+		testHarness.snapshot(2L, 2L);
+
+		TestUtils.checkLocalFs(outDir, 3, 0);
+
+		Map<File, String> contents = TestUtils.getFileContentByPath(outDir);
+		int fileCounter = 0;
+		for (Map.Entry<File, String> fileContents : contents.entrySet()) {
+			if (fileContents.getKey().getName().contains(partFileName1)) {
+				fileCounter++;
+				Assert.assertEquals("test1@1\n", fileContents.getValue());
+				Assert.assertEquals("1", fileContents.getKey().getParentFile().getName());
+			} else if (fileContents.getKey().getName().contains(partFileName2)) {
+				fileCounter++;
+				Assert.assertEquals("test1@2\n", fileContents.getValue());
+				Assert.assertEquals("2", fileContents.getKey().getParentFile().getName());
+			} else if (fileContents.getKey().getName().contains(partFileName3)) {
+				fileCounter++;
+				Assert.assertEquals("test1@3\n", fileContents.getValue());
+				Assert.assertEquals("3", fileContents.getKey().getParentFile().getName());
+			}
+		}
+		Assert.assertEquals(3L, fileCounter);
+
+		// we acknowledge the latest checkpoint, so everything should be published.
+		testHarness.notifyOfCompletedCheckpoint(2L);
+
+		TestUtils.checkLocalFs(outDir, 0, 3);
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
@@ -20,6 +20,9 @@ package org.apache.flink.streaming.api.functions.sink.filesystem;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.functions.sink.filesystem.TestUtils.Tuple2Encoder;
+import org.apache.flink.streaming.api.functions.sink.filesystem.TestUtils.TupleToIntegerBucketer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -401,6 +404,65 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 
 		// at close it is not moved to final.
 		TestUtils.checkLocalFs(outDir, 1, 3);
+	}
+
+	@Test
+	public void testClosingWithCustomizedBucketer() throws Exception {
+		final File outDir = TEMP_FOLDER.newFolder();
+		final long partMaxSize = 2L;
+		final long inactivityInterval = 100L;
+		final RollingPolicy<Tuple2<String, Integer>, Integer> rollingPolicy =
+				DefaultRollingPolicy
+						.create()
+						.withMaxPartSize(partMaxSize)
+						.withRolloverInterval(inactivityInterval)
+						.withInactivityInterval(inactivityInterval)
+						.build();
+
+		try (
+				OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness =
+						TestUtils.createCustomizedRescalingTestSink(outDir, 1, 0, 100L, new TupleToIntegerBucketer(), new Tuple2Encoder(), rollingPolicy, new DefaultBucketFactoryImpl<>());
+		) {
+			testHarness.setup();
+			testHarness.open();
+
+			testHarness.setProcessingTime(0L);
+
+			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 1), 1L));
+			testHarness.processElement(new StreamRecord<>(Tuple2.of("test2", 2), 1L));
+			TestUtils.checkLocalFs(outDir, 2, 0);
+
+			// this is to check the inactivity threshold
+			testHarness.setProcessingTime(101L);
+			TestUtils.checkLocalFs(outDir, 2, 0);
+
+			testHarness.processElement(new StreamRecord<>(Tuple2.of("test3", 3), 1L));
+			TestUtils.checkLocalFs(outDir, 3, 0);
+
+			testHarness.snapshot(0L, 1L);
+			TestUtils.checkLocalFs(outDir, 3, 0);
+
+			testHarness.notifyOfCompletedCheckpoint(0L);
+			TestUtils.checkLocalFs(outDir, 0, 3);
+
+			testHarness.processElement(new StreamRecord<>(Tuple2.of("test4", 4), 10L));
+			TestUtils.checkLocalFs(outDir, 1, 3);
+
+			testHarness.snapshot(1L, 0L);
+			testHarness.notifyOfCompletedCheckpoint(1L);
+		}
+
+		// at close all files moved to final.
+		TestUtils.checkLocalFs(outDir, 0, 4);
+
+		// check file content and bucket ID.
+		Map<File, String> contents = TestUtils.getFileContentByPath(outDir);
+		for (Map.Entry<File, String> fileContents : contents.entrySet()) {
+			Integer bucketId = Integer.parseInt(fileContents.getKey().getParentFile().getName());
+
+			Assert.assertTrue(bucketId >= 1 && bucketId <= 4);
+			Assert.assertEquals(String.format("test%d@%d\n", bucketId, bucketId), fileContents.getValue());
+		}
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
@@ -38,6 +38,9 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -68,25 +71,18 @@ public class TestUtils {
 						.withInactivityInterval(inactivityInterval)
 						.build();
 
-		final BucketAssigner<Tuple2<String, Integer>, String> bucketer = new TupleToStringBucketer();
-
-		final Encoder<Tuple2<String, Integer>> encoder = (element, stream) -> {
-			stream.write((element.f0 + '@' + element.f1).getBytes(StandardCharsets.UTF_8));
-			stream.write('\n');
-		};
-
-		return createCustomRescalingTestSink(
+		return createRescalingTestSink(
 				outDir,
 				totalParallelism,
 				taskIdx,
 				10L,
-				bucketer,
-				encoder,
+				new TupleToStringBucketer(),
+				new Tuple2Encoder(),
 				rollingPolicy,
 				new DefaultBucketFactoryImpl<>());
 	}
 
-	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createCustomRescalingTestSink(
+	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createRescalingTestSink(
 			final File outDir,
 			final int totalParallelism,
 			final int taskIdx,
@@ -107,6 +103,26 @@ public class TestUtils {
 		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
 	}
 
+	static <ID> OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createCustomizedRescalingTestSink(
+			final File outDir,
+			final int totalParallelism,
+			final int taskIdx,
+			final long bucketCheckInterval,
+			final BucketAssigner<Tuple2<String, Integer>, ID> bucketer,
+			final Encoder<Tuple2<String, Integer>> writer,
+			final RollingPolicy<Tuple2<String, Integer>, ID> rollingPolicy,
+			final BucketFactory<Tuple2<String, Integer>, ID> bucketFactory) throws Exception {
+
+		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
+				.forRowFormat(new Path(outDir.toURI()), writer)
+				.withNewBucketAssignerAndPolicy(bucketer, rollingPolicy)
+				.withBucketCheckInterval(bucketCheckInterval)
+				.withBucketFactory(bucketFactory)
+				.build();
+
+		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
+	}
+
 	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createTestSinkWithBulkEncoder(
 			final File outDir,
 			final int totalParallelism,
@@ -119,6 +135,25 @@ public class TestUtils {
 		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
 				.forBulkFormat(new Path(outDir.toURI()), writer)
 				.withBucketAssigner(bucketer)
+				.withBucketCheckInterval(bucketCheckInterval)
+				.withBucketFactory(bucketFactory)
+				.build();
+
+		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
+	}
+
+	static <ID> OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createTestSinkWithCustomizedBulkEncoder(
+			final File outDir,
+			final int totalParallelism,
+			final int taskIdx,
+			final long bucketCheckInterval,
+			final BucketAssigner<Tuple2<String, Integer>, ID> bucketer,
+			final BulkWriter.Factory<Tuple2<String, Integer>> writer,
+			final BucketFactory<Tuple2<String, Integer>, ID> bucketFactory) throws Exception {
+
+		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
+				.forBulkFormat(new Path(outDir.toURI()), writer)
+				.withNewBucketAssigner(bucketer)
 				.withBucketCheckInterval(bucketCheckInterval)
 				.withBucketFactory(bucketFactory)
 				.build();
@@ -156,6 +191,21 @@ public class TestUtils {
 		return contents;
 	}
 
+	/**
+	 * A simple {@link Encoder} that encodes {@code Tuple2} object.
+	 */
+	static class Tuple2Encoder implements Encoder<Tuple2<String, Integer>> {
+		@Override
+		public void encode(Tuple2<String, Integer> element, OutputStream stream) throws IOException {
+			stream.write((element.f0 + '@' + element.f1).getBytes(StandardCharsets.UTF_8));
+			stream.write('\n');
+		}
+	}
+
+	/**
+	 * A simple {@link BucketAssigner} that returns the first (String) element of a {@code Tuple2}
+	 * object as the bucket id.
+	 */
 	static class TupleToStringBucketer implements BucketAssigner<Tuple2<String, Integer>, String> {
 
 		private static final long serialVersionUID = 1L;
@@ -168,6 +218,48 @@ public class TestUtils {
 		@Override
 		public SimpleVersionedSerializer<String> getSerializer() {
 			return SimpleVersionedStringSerializer.INSTANCE;
+		}
+	}
+
+	/**
+	 * A simple {@link BucketAssigner} that returns the second (Integer) element of a {@code Tuple2}
+	 * object as the bucket id.
+	 */
+	static class TupleToIntegerBucketer implements BucketAssigner<Tuple2<String, Integer>, Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Integer getBucketId(Tuple2<String, Integer> element, Context context) {
+			return element.f1;
+		}
+
+		@Override
+		public SimpleVersionedSerializer<Integer> getSerializer() {
+			return new SimpleVersionedIntegerSerializer();
+		}
+	}
+
+	private static final class SimpleVersionedIntegerSerializer implements SimpleVersionedSerializer<Integer> {
+		static final int VERSION = 1;
+
+		private SimpleVersionedIntegerSerializer() {
+		}
+
+		public int getVersion() {
+			return 1;
+		}
+
+		public byte[] serialize(Integer value) {
+			byte[] bytes = new byte[4];
+			ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).putInt(value);
+			return bytes;
+		}
+
+		public Integer deserialize(int version, byte[] serialized) throws IOException {
+			Assert.assertEquals(1L, (long) version);
+			Assert.assertEquals(4L, serialized.length);
+			return ByteBuffer.wrap(serialized).order(ByteOrder.LITTLE_ENDIAN).getInt();
 		}
 	}
 


### PR DESCRIPTION
Cherry pick from Lyft StreamingFileSink Apache Flink [commit](https://github.com/apache/flink/commit/adfe011bc6fed36e30b3078bd3b6dbc0953f2ddf). 

Also in the PR: fix a number of checkstyle failures in the original branch.

> This PR makes the StreamingFileSink protected and the builders
> mutable so that they can be subclassed. In order for the user
> to subclass the StreamingFileSink, he has to override the
> forRowFormat/forBulkFormat depending on his needs and the
> corresponding builder so its the build() method returns the
> subclass and not the original StreamingFileSink.
> 