### PR TITLE
[FLINK-13864][fs-connector] Make StreamingFileSink extensible

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -110,7 +110,7 @@ public class StreamingFileSink<IN>
 
 	private final long bucketCheckInterval;
 
-	private final StreamingFileSink.BucketsBuilder<IN, ?> bucketsBuilder;
+	private final StreamingFileSink.BucketsBuilder<IN, ?, ? extends BucketsBuilder<IN, ?, ?>> bucketsBuilder;
 
 	// --------------------------- runtime fields -----------------------------
 
@@ -125,11 +125,24 @@ public class StreamingFileSink<IN>
 	private transient ListState<Long> maxPartCountersState;
 
 	/**
-	 * Creates a new {@code StreamingFileSink} that writes files to the given base directory.
+	 * Creates a new {@code StreamingFileSink} that writes files in row-based format to the given base directory.
 	 */
 	protected StreamingFileSink(
-			final StreamingFileSink.BucketsBuilder<IN, ?> bucketsBuilder,
-			final long bucketCheckInterval) {
+		final RowFormatBuilder<IN, ?, ? extends BucketsBuilder<IN, ?, ?>> bucketsBuilder,
+		final long bucketCheckInterval) {
+
+		Preconditions.checkArgument(bucketCheckInterval > 0L);
+
+		this.bucketsBuilder = Preconditions.checkNotNull(bucketsBuilder);
+		this.bucketCheckInterval = bucketCheckInterval;
+	}
+
+	/**
+	 * Creates a new {@code StreamingFileSink} that writes files in bulk-encoded format to the given base directory.
+	 */
+	protected StreamingFileSink(
+		final BulkFormatBuilder<IN, ?, ? extends BucketsBuilder<IN, ?, ?>> bucketsBuilder,
+		final long bucketCheckInterval) {
 
 		Preconditions.checkArgument(bucketCheckInterval > 0L);
 
@@ -149,7 +162,7 @@ public class StreamingFileSink<IN>
 	 * @return The builder where the remaining of the configuration parameters for the sink can be configured.
 	 * In order to instantiate the sink, call {@link RowFormatBuilder#build()} after specifying the desired parameters.
 	 */
-	public static <IN> StreamingFileSink.RowFormatBuilder<IN, String> forRowFormat(
+	public static <IN> StreamingFileSink.RowFormatBuilder<IN, String, ? extends RowFormatBuilder<IN, String, ?>> forRowFormat(
 			final Path basePath, final Encoder<IN> encoder) {
 		return new StreamingFileSink.RowFormatBuilder<>(basePath, encoder, new DateTimeBucketAssigner<>());
 	}
@@ -162,7 +175,7 @@ public class StreamingFileSink<IN>
 	 * @return The builder where the remaining of the configuration parameters for the sink can be configured.
 	 * In order to instantiate the sink, call {@link RowFormatBuilder#build()} after specifying the desired parameters.
 	 */
-	public static <IN> StreamingFileSink.BulkFormatBuilder<IN, String> forBulkFormat(
+	public static <IN> StreamingFileSink.BulkFormatBuilder<IN, String, ? extends BulkFormatBuilder<IN, String, ?>> forBulkFormat(
 			final Path basePath, final BulkWriter.Factory<IN> writerFactory) {
 		return new StreamingFileSink.BulkFormatBuilder<>(basePath, writerFactory, new DateTimeBucketAssigner<>());
 	}
@@ -170,9 +183,16 @@ public class StreamingFileSink<IN>
 	/**
 	 * The base abstract class for the {@link RowFormatBuilder} and {@link BulkFormatBuilder}.
 	 */
-	protected abstract static class BucketsBuilder<IN, BucketID> implements Serializable {
+	private abstract static class BucketsBuilder<IN, BucketID, T extends BucketsBuilder<IN, BucketID, T>> implements Serializable {
 
 		private static final long serialVersionUID = 1L;
+
+		protected static final long DEFAULT_BUCKET_CHECK_INTERVAL = 60L * 1000L;
+
+		@SuppressWarnings("unchecked")
+		protected T self() {
+			return (T) this;
+		}
 
 		abstract Buckets<IN, BucketID> createBuckets(final int subtaskIndex) throws IOException;
 	}
@@ -181,27 +201,27 @@ public class StreamingFileSink<IN>
 	 * A builder for configuring the sink for row-wise encoding formats.
 	 */
 	@PublicEvolving
-	public static class RowFormatBuilder<IN, BucketID> extends StreamingFileSink.BucketsBuilder<IN, BucketID> {
+	public static class RowFormatBuilder<IN, BucketID, T extends RowFormatBuilder<IN, BucketID, T>> extends StreamingFileSink.BucketsBuilder<IN, BucketID, T> {
 
 		private static final long serialVersionUID = 1L;
 
-		private final long bucketCheckInterval;
+		private long bucketCheckInterval;
 
 		private final Path basePath;
 
-		private final Encoder<IN> encoder;
+		private Encoder<IN> encoder;
 
-		private final BucketAssigner<IN, BucketID> bucketAssigner;
+		private BucketAssigner<IN, BucketID> bucketAssigner;
 
-		private final RollingPolicy<IN, BucketID> rollingPolicy;
+		private RollingPolicy<IN, BucketID> rollingPolicy;
 
-		private final BucketFactory<IN, BucketID> bucketFactory;
+		private BucketFactory<IN, BucketID> bucketFactory;
 
-		RowFormatBuilder(Path basePath, Encoder<IN> encoder, BucketAssigner<IN, BucketID> bucketAssigner) {
-			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.create().build(), 60L * 1000L, new DefaultBucketFactoryImpl<>());
+		protected RowFormatBuilder(Path basePath, Encoder<IN> encoder, BucketAssigner<IN, BucketID> bucketAssigner) {
+			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.create().build(), DEFAULT_BUCKET_CHECK_INTERVAL, new DefaultBucketFactoryImpl<>());
 		}
 
-		private RowFormatBuilder(
+		protected RowFormatBuilder(
 				Path basePath,
 				Encoder<IN> encoder,
 				BucketAssigner<IN, BucketID> assigner,
@@ -216,25 +236,39 @@ public class StreamingFileSink<IN>
 			this.bucketFactory = Preconditions.checkNotNull(bucketFactory);
 		}
 
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketCheckInterval(final long interval) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, interval, bucketFactory);
+		public long getBucketCheckInterval() {
+			return bucketCheckInterval;
 		}
 
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketAssigner(final BucketAssigner<IN, BucketID> assigner) {
-			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), rollingPolicy, bucketCheckInterval, bucketFactory);
+		public T withBucketCheckInterval(final long interval) {
+			this.bucketCheckInterval = interval;
+			return self();
 		}
 
-		public StreamingFileSink.RowFormatBuilder<IN, BucketID> withRollingPolicy(final RollingPolicy<IN, BucketID> policy) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, Preconditions.checkNotNull(policy), bucketCheckInterval, bucketFactory);
+		public T withBucketAssigner(final BucketAssigner<IN, BucketID> assigner) {
+			this.bucketAssigner = Preconditions.checkNotNull(assigner);
+			return self();
 		}
 
-		public <ID> StreamingFileSink.RowFormatBuilder<IN, ID> withBucketAssignerAndPolicy(final BucketAssigner<IN, ID> assigner, final RollingPolicy<IN, ID> policy) {
+		public T withRollingPolicy(final RollingPolicy<IN, BucketID> policy) {
+			this.rollingPolicy = Preconditions.checkNotNull(policy);
+			return self();
+		}
+
+		public <ID> StreamingFileSink.RowFormatBuilder<IN, ID, ? extends RowFormatBuilder<IN, ID, ?>> withNewBucketAssignerAndPolicy(final BucketAssigner<IN, ID> assigner, final RollingPolicy<IN, ID> policy) {
+			Preconditions.checkState(bucketFactory.getClass() == DefaultBucketFactoryImpl.class, "newBuilderWithBucketAssignerAndPolicy() cannot be called after specifying a customized bucket factory");
 			return new RowFormatBuilder<>(basePath, encoder, Preconditions.checkNotNull(assigner), Preconditions.checkNotNull(policy), bucketCheckInterval, new DefaultBucketFactoryImpl<>());
 		}
 
 		/** Creates the actual sink. */
 		public StreamingFileSink<IN> build() {
 			return new StreamingFileSink<>(this, bucketCheckInterval);
+		}
+
+		@VisibleForTesting
+		T withBucketFactory(final BucketFactory<IN, BucketID> factory) {
+			this.bucketFactory = Preconditions.checkNotNull(factory);
+			return self();
 		}
 
 		@Override
@@ -247,33 +281,28 @@ public class StreamingFileSink<IN>
 					rollingPolicy,
 					subtaskIndex);
 		}
-
-		@VisibleForTesting
-		StreamingFileSink.RowFormatBuilder<IN, BucketID> withBucketFactory(final BucketFactory<IN, BucketID> factory) {
-			return new RowFormatBuilder<>(basePath, encoder, bucketAssigner, rollingPolicy, bucketCheckInterval, Preconditions.checkNotNull(factory));
-		}
 	}
 
 	/**
 	 * A builder for configuring the sink for bulk-encoding formats, e.g. Parquet/ORC.
 	 */
 	@PublicEvolving
-	public static class BulkFormatBuilder<IN, BucketID> extends StreamingFileSink.BucketsBuilder<IN, BucketID> {
+	public static class BulkFormatBuilder<IN, BucketID, T extends BulkFormatBuilder<IN, BucketID, T>> extends StreamingFileSink.BucketsBuilder<IN, BucketID, T> {
 
 		private static final long serialVersionUID = 1L;
 
-		private final long bucketCheckInterval;
+		private long bucketCheckInterval;
 
 		private final Path basePath;
 
-		private final BulkWriter.Factory<IN> writerFactory;
+		private BulkWriter.Factory<IN> writerFactory;
 
-		private final BucketAssigner<IN, BucketID> bucketAssigner;
+		private BucketAssigner<IN, BucketID> bucketAssigner;
 
-		private final BucketFactory<IN, BucketID> bucketFactory;
+		private BucketFactory<IN, BucketID> bucketFactory;
 
-		BulkFormatBuilder(Path basePath, BulkWriter.Factory<IN> writerFactory, BucketAssigner<IN, BucketID> assigner) {
-			this(basePath, writerFactory, assigner, 60L * 1000L, new DefaultBucketFactoryImpl<>());
+		protected BulkFormatBuilder(Path basePath, BulkWriter.Factory<IN> writerFactory, BucketAssigner<IN, BucketID> assigner) {
+			this(basePath, writerFactory, assigner, DEFAULT_BUCKET_CHECK_INTERVAL, new DefaultBucketFactoryImpl<>());
 		}
 
 		private BulkFormatBuilder(
@@ -289,17 +318,29 @@ public class StreamingFileSink<IN>
 			this.bucketFactory = Preconditions.checkNotNull(bucketFactory);
 		}
 
-		public StreamingFileSink.BulkFormatBuilder<IN, BucketID> withBucketCheckInterval(long interval) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, interval, bucketFactory);
+		public long getBucketCheckInterval() {
+			return bucketCheckInterval;
 		}
 
-		public <ID> StreamingFileSink.BulkFormatBuilder<IN, ID> withBucketAssigner(BucketAssigner<IN, ID> assigner) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, Preconditions.checkNotNull(assigner), bucketCheckInterval, new DefaultBucketFactoryImpl<>());
+		public T withBucketCheckInterval(long interval) {
+			this.bucketCheckInterval = interval;
+			return self();
+		}
+
+		public T withBucketAssigner(BucketAssigner<IN, BucketID> assigner) {
+			this.bucketAssigner = Preconditions.checkNotNull(assigner);
+			return self();
 		}
 
 		@VisibleForTesting
-		StreamingFileSink.BulkFormatBuilder<IN, BucketID> withBucketFactory(final BucketFactory<IN, BucketID> factory) {
-			return new BulkFormatBuilder<>(basePath, writerFactory, bucketAssigner, bucketCheckInterval, Preconditions.checkNotNull(factory));
+		T withBucketFactory(final BucketFactory<IN, BucketID> factory) {
+			this.bucketFactory = Preconditions.checkNotNull(factory);
+			return self();
+		}
+
+		public <ID> StreamingFileSink.BulkFormatBuilder<IN, ID, ? extends BulkFormatBuilder<IN, ID, ?>> withNewBucketAssigner(final BucketAssigner<IN, ID> assigner) {
+			Preconditions.checkState(bucketFactory.getClass() == DefaultBucketFactoryImpl.class, "newBuilderWithBucketAssigner() cannot be called after specifying a customized bucket factory");
+			return new BulkFormatBuilder<>(basePath, writerFactory, Preconditions.checkNotNull(assigner), bucketCheckInterval, new DefaultBucketFactoryImpl<>());
 		}
 
 		/** Creates the actual sink. */

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
@@ -61,43 +61,123 @@ public class BulkWriterTest extends TestLogger {
 								new TestBulkWriterFactory(),
 								new DefaultBucketFactoryImpl<>())
 		) {
-
-			testHarness.setup();
-			testHarness.open();
-
-			// this creates a new bucket "test1" and part-0-0
-			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 1), 1L));
-			TestUtils.checkLocalFs(outDir, 1, 0);
-
-			// we take a checkpoint so we roll.
-			testHarness.snapshot(1L, 1L);
-
-			// these will close part-0-0 and open part-0-1
-			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 2), 2L));
-			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 3), 3L));
-
-			// we take a checkpoint so we roll again.
-			testHarness.snapshot(2L, 2L);
-
-			TestUtils.checkLocalFs(outDir, 2, 0);
-
-			Map<File, String> contents = TestUtils.getFileContentByPath(outDir);
-			int fileCounter = 0;
-			for (Map.Entry<File, String> fileContents : contents.entrySet()) {
-				if (fileContents.getKey().getName().contains(".part-0-0.inprogress")) {
-					fileCounter++;
-					Assert.assertEquals("test1@1\n", fileContents.getValue());
-				} else if (fileContents.getKey().getName().contains(".part-0-1.inprogress")) {
-					fileCounter++;
-					Assert.assertEquals("test1@2\ntest1@3\n", fileContents.getValue());
-				}
-			}
-			Assert.assertEquals(2L, fileCounter);
-
-			// we acknowledge the latest checkpoint, so everything should be published.
-			testHarness.notifyOfCompletedCheckpoint(2L);
-			TestUtils.checkLocalFs(outDir, 0, 2);
+			testPartFilesWithStringBucketer(testHarness, outDir, ".part-0-0.inprogress", ".part-0-1.inprogress");
 		}
+	}
+
+	@Test
+	public void testCustomBulkWriterWithBucketAssigner() throws Exception {
+		final File outDir = TEMP_FOLDER.newFolder();
+
+		// we set the max bucket size to small so that we can know when it rolls
+		try (
+				OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness =
+						TestUtils.createTestSinkWithCustomizedBulkEncoder(
+								outDir,
+								1,
+								0,
+								10L,
+								// use a customized bucketer with Integer bucket ID
+								new TestUtils.TupleToIntegerBucketer(),
+								new TestBulkWriterFactory(),
+								new DefaultBucketFactoryImpl<>())
+		) {
+			testPartFilesWithIntegerBucketer(testHarness, outDir, ".part-0-0.inprogress", ".part-0-1.inprogress", ".part-0-2.inprogress");
+		}
+	}
+
+	private void testPartFilesWithStringBucketer(
+			OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness,
+			File outDir,
+			String partFileName1,
+			String partFileName2) throws Exception {
+
+		testHarness.setup();
+		testHarness.open();
+
+		// this creates a new bucket "test1" and part-0-0
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 1), 1L));
+		TestUtils.checkLocalFs(outDir, 1, 0);
+
+		// we take a checkpoint so we roll.
+		testHarness.snapshot(1L, 1L);
+
+		// these will close part-0-0 and open part-0-1
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 2), 2L));
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 3), 3L));
+
+		// we take a checkpoint so we roll again.
+		testHarness.snapshot(2L, 2L);
+
+		TestUtils.checkLocalFs(outDir, 2, 0);
+
+		Map<File, String> contents = TestUtils.getFileContentByPath(outDir);
+		int fileCounter = 0;
+		for (Map.Entry<File, String> fileContents : contents.entrySet()) {
+			if (fileContents.getKey().getName().contains(".part-0-0.inprogress")) {
+				fileCounter++;
+				Assert.assertEquals("test1@1\n", fileContents.getValue());
+			} else if (fileContents.getKey().getName().contains(".part-0-1.inprogress")) {
+				fileCounter++;
+				Assert.assertEquals("test1@2\ntest1@3\n", fileContents.getValue());
+			}
+		}
+		Assert.assertEquals(2L, fileCounter);
+
+		// we acknowledge the latest checkpoint, so everything should be published.
+		testHarness.notifyOfCompletedCheckpoint(2L);
+		TestUtils.checkLocalFs(outDir, 0, 2);
+	}
+
+	private void testPartFilesWithIntegerBucketer(
+			OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness,
+			File outDir,
+			String partFileName1,
+			String partFileName2,
+			String partFileName3) throws Exception {
+
+		testHarness.setup();
+		testHarness.open();
+
+		// this creates a new bucket "test1" and part-0-0
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 1), 1L));
+		TestUtils.checkLocalFs(outDir, 1, 0);
+
+		// we take a checkpoint so we roll.
+		testHarness.snapshot(1L, 1L);
+
+		// these will close part-0-0 and open part-0-1 and part-0-2
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 2), 2L));
+		testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 3), 3L));
+
+		// we take a checkpoint so we roll again.
+		testHarness.snapshot(2L, 2L);
+
+		TestUtils.checkLocalFs(outDir, 3, 0);
+
+		Map<File, String> contents = TestUtils.getFileContentByPath(outDir);
+		int fileCounter = 0;
+		for (Map.Entry<File, String> fileContents : contents.entrySet()) {
+			if (fileContents.getKey().getName().contains(partFileName1)) {
+				fileCounter++;
+				Assert.assertEquals("test1@1\n", fileContents.getValue());
+				Assert.assertEquals("1", fileContents.getKey().getParentFile().getName());
+			} else if (fileContents.getKey().getName().contains(partFileName2)) {
+				fileCounter++;
+				Assert.assertEquals("test1@2\n", fileContents.getValue());
+				Assert.assertEquals("2", fileContents.getKey().getParentFile().getName());
+			} else if (fileContents.getKey().getName().contains(partFileName3)) {
+				fileCounter++;
+				Assert.assertEquals("test1@3\n", fileContents.getValue());
+				Assert.assertEquals("3", fileContents.getKey().getParentFile().getName());
+			}
+		}
+		Assert.assertEquals(3L, fileCounter);
+
+		// we acknowledge the latest checkpoint, so everything should be published.
+		testHarness.notifyOfCompletedCheckpoint(2L);
+
+		TestUtils.checkLocalFs(outDir, 0, 3);
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/LocalStreamingFileSinkTest.java
@@ -20,6 +20,9 @@ package org.apache.flink.streaming.api.functions.sink.filesystem;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.functions.sink.filesystem.TestUtils.Tuple2Encoder;
+import org.apache.flink.streaming.api.functions.sink.filesystem.TestUtils.TupleToIntegerBucketer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.DefaultRollingPolicy;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -401,6 +404,65 @@ public class LocalStreamingFileSinkTest extends TestLogger {
 
 		// at close it is not moved to final.
 		TestUtils.checkLocalFs(outDir, 1, 3);
+	}
+
+	@Test
+	public void testClosingWithCustomizedBucketer() throws Exception {
+		final File outDir = TEMP_FOLDER.newFolder();
+		final long partMaxSize = 2L;
+		final long inactivityInterval = 100L;
+		final RollingPolicy<Tuple2<String, Integer>, Integer> rollingPolicy =
+				DefaultRollingPolicy
+						.create()
+						.withMaxPartSize(partMaxSize)
+						.withRolloverInterval(inactivityInterval)
+						.withInactivityInterval(inactivityInterval)
+						.build();
+
+		try (
+				OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> testHarness =
+						TestUtils.createCustomizedRescalingTestSink(outDir, 1, 0, 100L, new TupleToIntegerBucketer(), new Tuple2Encoder(), rollingPolicy, new DefaultBucketFactoryImpl<>());
+		) {
+			testHarness.setup();
+			testHarness.open();
+
+			testHarness.setProcessingTime(0L);
+
+			testHarness.processElement(new StreamRecord<>(Tuple2.of("test1", 1), 1L));
+			testHarness.processElement(new StreamRecord<>(Tuple2.of("test2", 2), 1L));
+			TestUtils.checkLocalFs(outDir, 2, 0);
+
+			// this is to check the inactivity threshold
+			testHarness.setProcessingTime(101L);
+			TestUtils.checkLocalFs(outDir, 2, 0);
+
+			testHarness.processElement(new StreamRecord<>(Tuple2.of("test3", 3), 1L));
+			TestUtils.checkLocalFs(outDir, 3, 0);
+
+			testHarness.snapshot(0L, 1L);
+			TestUtils.checkLocalFs(outDir, 3, 0);
+
+			testHarness.notifyOfCompletedCheckpoint(0L);
+			TestUtils.checkLocalFs(outDir, 0, 3);
+
+			testHarness.processElement(new StreamRecord<>(Tuple2.of("test4", 4), 10L));
+			TestUtils.checkLocalFs(outDir, 1, 3);
+
+			testHarness.snapshot(1L, 0L);
+			testHarness.notifyOfCompletedCheckpoint(1L);
+		}
+
+		// at close all files moved to final.
+		TestUtils.checkLocalFs(outDir, 0, 4);
+
+		// check file content and bucket ID.
+		Map<File, String> contents = TestUtils.getFileContentByPath(outDir);
+		for (Map.Entry<File, String> fileContents : contents.entrySet()) {
+			Integer bucketId = Integer.parseInt(fileContents.getKey().getParentFile().getName());
+
+			Assert.assertTrue(bucketId >= 1 && bucketId <= 4);
+			Assert.assertEquals(String.format("test%d@%d\n", bucketId, bucketId), fileContents.getValue());
+		}
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/TestUtils.java
@@ -38,6 +38,9 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -68,25 +71,18 @@ public class TestUtils {
 						.withInactivityInterval(inactivityInterval)
 						.build();
 
-		final BucketAssigner<Tuple2<String, Integer>, String> bucketer = new TupleToStringBucketer();
-
-		final Encoder<Tuple2<String, Integer>> encoder = (element, stream) -> {
-			stream.write((element.f0 + '@' + element.f1).getBytes(StandardCharsets.UTF_8));
-			stream.write('\n');
-		};
-
-		return createCustomRescalingTestSink(
+		return createRescalingTestSink(
 				outDir,
 				totalParallelism,
 				taskIdx,
 				10L,
-				bucketer,
-				encoder,
+				new TupleToStringBucketer(),
+				new Tuple2Encoder(),
 				rollingPolicy,
 				new DefaultBucketFactoryImpl<>());
 	}
 
-	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createCustomRescalingTestSink(
+	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createRescalingTestSink(
 			final File outDir,
 			final int totalParallelism,
 			final int taskIdx,
@@ -107,6 +103,26 @@ public class TestUtils {
 		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
 	}
 
+	static <ID> OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createCustomizedRescalingTestSink(
+			final File outDir,
+			final int totalParallelism,
+			final int taskIdx,
+			final long bucketCheckInterval,
+			final BucketAssigner<Tuple2<String, Integer>, ID> bucketer,
+			final Encoder<Tuple2<String, Integer>> writer,
+			final RollingPolicy<Tuple2<String, Integer>, ID> rollingPolicy,
+			final BucketFactory<Tuple2<String, Integer>, ID> bucketFactory) throws Exception {
+
+		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
+				.forRowFormat(new Path(outDir.toURI()), writer)
+				.withNewBucketAssignerAndPolicy(bucketer, rollingPolicy)
+				.withBucketCheckInterval(bucketCheckInterval)
+				.withBucketFactory(bucketFactory)
+				.build();
+
+		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
+	}
+
 	static OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createTestSinkWithBulkEncoder(
 			final File outDir,
 			final int totalParallelism,
@@ -119,6 +135,25 @@ public class TestUtils {
 		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
 				.forBulkFormat(new Path(outDir.toURI()), writer)
 				.withBucketAssigner(bucketer)
+				.withBucketCheckInterval(bucketCheckInterval)
+				.withBucketFactory(bucketFactory)
+				.build();
+
+		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), MAX_PARALLELISM, totalParallelism, taskIdx);
+	}
+
+	static <ID> OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Object> createTestSinkWithCustomizedBulkEncoder(
+			final File outDir,
+			final int totalParallelism,
+			final int taskIdx,
+			final long bucketCheckInterval,
+			final BucketAssigner<Tuple2<String, Integer>, ID> bucketer,
+			final BulkWriter.Factory<Tuple2<String, Integer>> writer,
+			final BucketFactory<Tuple2<String, Integer>, ID> bucketFactory) throws Exception {
+
+		StreamingFileSink<Tuple2<String, Integer>> sink = StreamingFileSink
+				.forBulkFormat(new Path(outDir.toURI()), writer)
+				.withNewBucketAssigner(bucketer)
 				.withBucketCheckInterval(bucketCheckInterval)
 				.withBucketFactory(bucketFactory)
 				.build();
@@ -156,6 +191,21 @@ public class TestUtils {
 		return contents;
 	}
 
+	/**
+	 * A simple {@link Encoder} that encodes {@code Tuple2} object.
+	 */
+	static class Tuple2Encoder implements Encoder<Tuple2<String, Integer>> {
+		@Override
+		public void encode(Tuple2<String, Integer> element, OutputStream stream) throws IOException {
+			stream.write((element.f0 + '@' + element.f1).getBytes(StandardCharsets.UTF_8));
+			stream.write('\n');
+		}
+	}
+
+	/**
+	 * A simple {@link BucketAssigner} that returns the first (String) element of a {@code Tuple2}
+	 * object as the bucket id.
+	 */
 	static class TupleToStringBucketer implements BucketAssigner<Tuple2<String, Integer>, String> {
 
 		private static final long serialVersionUID = 1L;
@@ -168,6 +218,48 @@ public class TestUtils {
 		@Override
 		public SimpleVersionedSerializer<String> getSerializer() {
 			return SimpleVersionedStringSerializer.INSTANCE;
+		}
+	}
+
+	/**
+	 * A simple {@link BucketAssigner} that returns the second (Integer) element of a {@code Tuple2}
+	 * object as the bucket id.
+	 */
+	static class TupleToIntegerBucketer implements BucketAssigner<Tuple2<String, Integer>, Integer> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Integer getBucketId(Tuple2<String, Integer> element, Context context) {
+			return element.f1;
+		}
+
+		@Override
+		public SimpleVersionedSerializer<Integer> getSerializer() {
+			return new SimpleVersionedIntegerSerializer();
+		}
+	}
+
+	private static final class SimpleVersionedIntegerSerializer implements SimpleVersionedSerializer<Integer> {
+		static final int VERSION = 1;
+
+		private SimpleVersionedIntegerSerializer() {
+		}
+
+		public int getVersion() {
+			return 1;
+		}
+
+		public byte[] serialize(Integer value) {
+			byte[] bytes = new byte[4];
+			ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).putInt(value);
+			return bytes;
+		}
+
+		public Integer deserialize(int version, byte[] serialized) throws IOException {
+			Assert.assertEquals(1L, (long) version);
+			Assert.assertEquals(4L, serialized.length);
+			return ByteBuffer.wrap(serialized).order(ByteOrder.LITTLE_ENDIAN).getInt();
 		}
 	}
 


### PR DESCRIPTION
Cherry pick commit [83d64fec8d3661dbee1f09916bb1067c93f5a0aa](https://github.com/lyft/flink/commit/83d64fec8d3661dbee1f09916bb1067c93f5a0aa) into `release-1.8-lyft` branch. 

> This PR makes the StreamingFileSink protected and the builders
> mutable so that they can be subclassed. In order for the user
> to subclass the StreamingFileSink, he has to override the
> forRowFormat/forBulkFormat depending on his needs and the
> corresponding builder so its the build() method returns the
> subclass and not the original StreamingFileSink.
> 
