### PR TITLE
[STRMCMP-860] Fix thread cancelation timeout problems

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/RecordEmitter.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/RecordEmitter.java
@@ -212,6 +212,10 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 						}
 					}
 				}
+				if (!running) {
+					// Make sure we can exit this loop so the thread can shut down
+					break runLoop;
+				}
 			}
 
 			// wait until ready to emit min or another queue receives elements
@@ -229,6 +233,10 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 						min = null;
 						continue runLoop;
 					}
+				}
+				if (!running) {
+					// Make sure we can exit this loop so the thread can shut down
+					break runLoop;
 				}
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/akka/DefaultQuarantineHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/akka/DefaultQuarantineHandler.java
@@ -77,7 +77,7 @@ public class DefaultQuarantineHandler implements QuarantineHandler {
 			log.error("Exception thrown when terminating the actor system", e);
 		} finally {
 			// now let's crash the JVM
-			System.exit(exitCode);
+			Runtime.getRuntime().halt(exitCode);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -407,7 +407,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 	public void onFatalError(Throwable exception) {
 		LOG.error("Fatal error occurred in the cluster entrypoint.", exception);
 
-		System.exit(RUNTIME_FAILURE_RETURN_CODE);
+		Runtime.getRuntime().halt(STARTUP_FAILURE_RETURN_CODE);
 	}
 
 	// --------------------------------------------------
@@ -535,7 +535,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 			clusterEntrypoint.startCluster();
 		} catch (ClusterEntrypointException e) {
 			LOG.error(String.format("Could not start cluster entrypoint %s.", clusterEntrypointName), e);
-			System.exit(STARTUP_FAILURE_RETURN_CODE);
+			Runtime.getRuntime().halt(STARTUP_FAILURE_RETURN_CODE);
 		}
 
 		clusterEntrypoint.getTerminationFuture().whenComplete((applicationStatus, throwable) -> {
@@ -548,7 +548,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 			}
 
 			LOG.info("Terminating cluster entrypoint process {} with exit code {}.", clusterEntrypointName, returnCode, throwable);
-			System.exit(returnCode);
+			Runtime.getRuntime().halt(returnCode);
 		});
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/StandaloneSessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/StandaloneSessionClusterEntrypoint.java
@@ -55,7 +55,7 @@ public class StandaloneSessionClusterEntrypoint extends SessionClusterEntrypoint
 		} catch (FlinkParseException e) {
 			LOG.error("Could not parse command line arguments {}.", args, e);
 			commandLineParser.printHelp(StandaloneSessionClusterEntrypoint.class.getSimpleName());
-			System.exit(1);
+			Runtime.getRuntime().halt(1);
 		}
 
 		Configuration configuration = loadConfiguration(entrypointClusterConfiguration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/process/ProcessReaper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/process/ProcessReaper.java
@@ -61,7 +61,7 @@ public class ProcessReaper extends UntypedActor {
 				}
 			}
 			finally {
-				System.exit(exitCode);
+				Runtime.getRuntime().halt(exitCode);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -263,7 +263,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 	}
 
 	private void terminateJVM() {
-		System.exit(RUNTIME_FAILURE_RETURN_CODE);
+		Runtime.getRuntime().halt(RUNTIME_FAILURE_RETURN_CODE);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -306,7 +306,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		} catch (Throwable t) {
 			final Throwable strippedThrowable = ExceptionUtils.stripException(t, UndeclaredThrowableException.class);
 			LOG.error("TaskManager initialization failed.", strippedThrowable);
-			System.exit(STARTUP_FAILURE_RETURN_CODE);
+			Runtime.getRuntime().halt(STARTUP_FAILURE_RETURN_CODE);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1047,7 +1047,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 								try {
 									LOG.error("FATAL! Watchdog thread failed to start.", t);
 								} catch (Throwable ignored) {}
-								System.exit(42);
+								Runtime.getRuntime().halt(42);
 							}
 						}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
@@ -41,7 +41,7 @@ public final class FatalExitExceptionHandler implements Thread.UncaughtException
 				"' produced an uncaught exception. Stopping the process...", e);
 		}
 		finally {
-			System.exit(-17);
+			Runtime.getRuntime().halt(-17);
 		}
 	}
 }


### PR DESCRIPTION
This attempts to fix the hanging task thread. Two possible scenarios:

(1) `cancelTask()` can be called from multiple locations. At least one of the
locations does not perform proper exception handling. Once a task is in the
CANCELING state and the cancelation timeout thread has not been started, the
task will linger forever.

(2) `taskCancellationTimeout` was non-volatile and is non-final which
theoretically could lead to a thread calling `cancelTask()` to read an outdated
value. It is first initialized with 0 which would disable the cancelation. The
value is written in the constructor which makes it unlikely but not impossible
to read the initial value:
https://stackoverflow.com/questions/33485625/non-volatile-fields-first-object-access-from-another-thread-java

We bring up the thread as soon as possible to avoid any problems running
it. Also we exit in case the thread fails to start.