### PR TITLE
[FLINK-16510] Ensure task manager process (and k8s pod) termination on fatal error

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -390,7 +390,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 	public void onFatalError(Throwable exception) {
 		LOG.error("Fatal error occurred in the cluster entrypoint.", exception);
 
-		System.exit(RUNTIME_FAILURE_RETURN_CODE);
+		Runtime.getRuntime().halt(RUNTIME_FAILURE_RETURN_CODE);
 	}
 
 	// --------------------------------------------------
@@ -518,7 +518,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 			clusterEntrypoint.startCluster();
 		} catch (ClusterEntrypointException e) {
 			LOG.error(String.format("Could not start cluster entrypoint %s.", clusterEntrypointName), e);
-			System.exit(STARTUP_FAILURE_RETURN_CODE);
+			Runtime.getRuntime().halt(STARTUP_FAILURE_RETURN_CODE);
 		}
 
 		clusterEntrypoint.getTerminationFuture().whenComplete((applicationStatus, throwable) -> {
@@ -531,7 +531,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 			}
 
 			LOG.info("Terminating cluster entrypoint process {} with exit code {}.", clusterEntrypointName, returnCode, throwable);
-			System.exit(returnCode);
+			Runtime.getRuntime().halt(returnCode);
 		});
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/StandaloneSessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/StandaloneSessionClusterEntrypoint.java
@@ -54,7 +54,7 @@ public class StandaloneSessionClusterEntrypoint extends SessionClusterEntrypoint
 		} catch (FlinkParseException e) {
 			LOG.error("Could not parse command line arguments {}.", args, e);
 			commandLineParser.printHelp(StandaloneSessionClusterEntrypoint.class.getSimpleName());
-			System.exit(1);
+			Runtime.getRuntime().halt(1);
 		}
 
 		Configuration configuration = loadConfiguration(entrypointClusterConfiguration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -267,7 +267,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 	}
 
 	private void terminateJVM() {
-		System.exit(RUNTIME_FAILURE_RETURN_CODE);
+		Runtime.getRuntime().halt(RUNTIME_FAILURE_RETURN_CODE);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -329,7 +329,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		} catch (Throwable t) {
 			final Throwable strippedThrowable = ExceptionUtils.stripException(t, UndeclaredThrowableException.class);
 			LOG.error("TaskManager initialization failed.", strippedThrowable);
-			System.exit(STARTUP_FAILURE_RETURN_CODE);
+			Runtime.getRuntime().halt(STARTUP_FAILURE_RETURN_CODE);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
@@ -41,7 +41,7 @@ public final class FatalExitExceptionHandler implements Thread.UncaughtException
 				"' produced an uncaught exception. Stopping the process...", e);
 		}
 		finally {
-			System.exit(-17);
+			Runtime.getRuntime().halt(-17);
 		}
 	}
 }


### PR DESCRIPTION
These are the missing changes from https://github.com/lyft/flink/commit/adcecf34fc2719e93d700de237ed9430697c793b

Let's verify they address the issue discussed in https://github.com/lyft/streamperfbench/pull/1065#issuecomment-651899129

We will need to work on an upstream solution regardless.