### PR TITLE
Add `python_requires` to Flink setup.cfg

### DIFF
--- a/flink-python/apache-flink-libraries/setup.cfg
+++ b/flink-python/apache-flink-libraries/setup.cfg
@@ -21,3 +21,6 @@ universal = 1
 
 [metadata]
 description-file = README.md
+
+[options]
+python_requires= >=3.8


### PR DESCRIPTION
Lyft internal dev infra changes require this tag to release this lib.