### PR TITLE
Translate version to be compatible with Java build

### DIFF
--- a/flink-python/apache-flink-libraries/setup.py
+++ b/flink-python/apache-flink-libraries/setup.py
@@ -98,7 +98,7 @@ try:
                   file=sys.stderr)
             sys.exit(-1)
         flink_version = VERSION.replace(".dev0", "-SNAPSHOT")
-        flink_version = VERSION.replace("+", "-")
+        flink_version = flink_version.replace("+", "-")
 
         FLINK_HOME = os.path.abspath(
             "../../flink-dist/target/flink-%s-bin/flink-%s" % (flink_version, flink_version))

--- a/flink-python/apache-flink-libraries/setup.py
+++ b/flink-python/apache-flink-libraries/setup.py
@@ -98,6 +98,8 @@ try:
                   file=sys.stderr)
             sys.exit(-1)
         flink_version = VERSION.replace(".dev0", "-SNAPSHOT")
+        flink_version = VERSION.replace("+", "-")
+
         FLINK_HOME = os.path.abspath(
             "../../flink-dist/target/flink-%s-bin/flink-%s" % (flink_version, flink_version))
 


### PR DESCRIPTION
The Java build replaces + with - in the path where it places artifacts.
We can translate the version analogously when picking up artifacts in the setup of apache-flink-libraries.