### PR TITLE
Package Lyft's flink-python with Lyft-internal apache-flink-libraries

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -179,7 +179,7 @@ except IOError:
           file=sys.stderr)
     sys.exit(-1)
 VERSION = __version__  # noqa
-APACHE_FLINK_VERSION = '1.13.0'
+APACHE_FLINK_LIBRARIES_VERSION = '1.13+lyft202208051659742888'
 
 
 with io.open(os.path.join(this_directory, 'README.md'), 'r', encoding='utf-8') as f:
@@ -254,7 +254,7 @@ try:
                   "is complete, or do this in the flink-python directory of the flink source "
                   "directory.")
             sys.exit(-1)
-    apache_flink_libraries_dependency = 'apache-flink-libraries==%s' % APACHE_FLINK_VERSION
+    apache_flink_libraries_dependency = 'apache-flink-libraries==%s' % APACHE_FLINK_LIBRARIES_VERSION
     script_names = ["pyflink-shell.sh", "find-flink-home.sh"]
     scripts = [os.path.join(SCRIPTS_TEMP_PATH, script) for script in script_names]
     scripts.append("pyflink/find_flink_home.py")


### PR DESCRIPTION
Pins Lyft-internal version of apache-flink-libraries to Lyft-internal PyFlink release.
It is also possible to use the version tag from the PyFlink release.
However, doing so creates a dependency in the deploy step process, i.e. AFL needs to be released before PyFlink.
Doing this instead to test.