### PR TITLE
unlink the symlink

### DIFF
--- a/flink-python/apache-flink-libraries/setup.py
+++ b/flink-python/apache-flink-libraries/setup.py
@@ -148,6 +148,8 @@ run sdist.
                        os.path.join(OPT_TEMP_PATH, OPT_PYTHON_JAR_NAME))
             os.symlink(os.path.join(OPT_PATH, OPT_SQL_CLIENT_JAR_NAME),
                        os.path.join(OPT_TEMP_PATH, OPT_SQL_CLIENT_JAR_NAME))
+            # Ensure the path we are trying to symlink to does not exist.
+            os.unlink(os.path.join(LIB_TEMP_PATH, LIB_FLINK_SQL_CONNECTOR_HIVE_JAR_NAME))
             os.symlink(os.path.join(LIB_PATH, LIB_FLINK_SQL_CONNECTOR_HIVE_JAR_NAME),
                        os.path.join(LIB_TEMP_PATH, LIB_FLINK_SQL_CONNECTOR_HIVE_JAR_NAME))
             os.symlink(PLUGINS_PATH, PLUGINS_TEMP_PATH)


### PR DESCRIPTION
```
    os.symlink(os.path.join(LIB_PATH, LIB_FLINK_SQL_CONNECTOR_HIVE_JAR_NAME),
FileExistsError: [Errno 17] File exists: '/src/streamingplatform/flink-release/flink/flink-dist/target/flink-1.13-lyft202208091660030006-bin/flink-1.13-lyft202208091660030006/lib/flink-sql-connector-hive-2.3.6_2.11-1.13-lyft202208091660030006.jar' -> 'deps/lib/flink-sql-connector-hive-2.3.6_2.11-1.13-lyft202208091660030006.jar'
```

Seeing this in CI which suggests that `deps/lib/flink-sql-connector-hive-2.3.6_2.11-1.13-lyft202208091660030006.jar` somehow already exists.

Reproduced as shown:

```
# after creating a symlink too foo called bar
>>> import os
>>> os.symlink('foo', 'bar')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
FileExistsError: [Errno 17] File exists: 'foo' -> 'bar'
>>> quit()
➜  symlink ls -l
total 0
lrwxr-xr-x  1 kgizdarski  staff  3 Aug  9 01:17 bar -> foo
➜  symlink ls
bar
```