### PR TITLE
[STRMHELP-197] Update Global Watermark When Idle

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -303,6 +303,9 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
     /** The maximum delta allowed for the reader to advance ahead of the shared global watermark. */
     public static final String WATERMARK_LOOKAHEAD_MILLIS = "flink.watermark.lookahead.millis";
 
+    /** Feature flag to update global watermark when idle. */
+    public static final String WATERMARK_SYNC_GLOBAL = "flink.watermark.sync.global";
+
     /**
      * The maximum number of records that will be buffered before suspending consumption of a shard.
      */
@@ -402,6 +405,8 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
     public static final long DEFAULT_SHARD_IDLE_INTERVAL_MILLIS = -1;
 
     public static final long DEFAULT_WATERMARK_SYNC_MILLIS = 30_000;
+
+    public static final boolean DEFAULT_WATERMARK_SYNC_GLOBAL = false;
 
     public static final int DEFAULT_EFO_HTTP_CLIENT_MAX_CONURRENCY = 10_000;
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -626,7 +626,19 @@ public class KinesisDataFetcher<T> {
                     watermarkTracker.setUpdateTimeoutMillis(
                             watermarkSyncMillis * 3); // synchronization latency
                     watermarkTracker.open(runtimeContext);
-                    new WatermarkSyncCallback(timerService, watermarkSyncMillis).start();
+                    boolean updateGlobalWatermarkForIdleSubtask =
+                            Boolean.parseBoolean(
+                                    getConsumerConfiguration()
+                                            .getProperty(
+                                                    ConsumerConfigConstants.WATERMARK_SYNC_GLOBAL,
+                                                    Boolean.toString(
+                                                            ConsumerConfigConstants
+                                                                    .DEFAULT_WATERMARK_SYNC_GLOBAL)));
+                    new WatermarkSyncCallback(
+                                    timerService,
+                                    watermarkSyncMillis,
+                                    updateGlobalWatermarkForIdleSubtask)
+                            .start();
                     // emit records ahead of watermark to offset synchronization latency
                     long lookaheadMillis =
                             Long.parseLong(
@@ -1172,6 +1184,14 @@ public class KinesisDataFetcher<T> {
             }
         }
 
+        LOG.debug(
+                "WatermarkEmitter subtask: {}, last watermark: {}, potential watermark: {}"
+                        + ", potential next watermark: {}",
+                indexOfThisConsumerSubtask,
+                lastWatermark,
+                potentialWatermark,
+                potentialNextWatermark);
+
         // advance watermark if possible (watermarks can only be ascending)
         if (potentialWatermark == Long.MAX_VALUE) {
             if (shardWatermarks.isEmpty() || shardIdleIntervalMillis > 0) {
@@ -1239,14 +1259,19 @@ public class KinesisDataFetcher<T> {
 
         private final ProcessingTimeService timerService;
         private final long interval;
+        private final boolean updateGlobalWatermarkForIdleSubtask;
         private long lastGlobalWatermark = Long.MIN_VALUE;
         private long propagatedLocalWatermark = Long.MIN_VALUE;
         private int stalledWatermarkIntervalCount = 0;
         private long lastLogged;
 
-        WatermarkSyncCallback(ProcessingTimeService timerService, long interval) {
+        WatermarkSyncCallback(
+                ProcessingTimeService timerService,
+                long interval,
+                boolean updateGlobalWatermarkForIdleSubtask) {
             this.timerService = checkNotNull(timerService);
             this.interval = interval;
+            this.updateGlobalWatermarkForIdleSubtask = updateGlobalWatermarkForIdleSubtask;
             MetricGroup shardMetricsGroup =
                     consumerMetricGroup.addGroup(
                             "subtaskId", String.valueOf(indexOfThisConsumerSubtask));
@@ -1267,7 +1292,9 @@ public class KinesisDataFetcher<T> {
                     globalWatermark = watermarkTracker.updateWatermark(nextWatermark);
                     propagatedLocalWatermark = nextWatermark;
                 } else {
-                    globalWatermark = watermarkTracker.getWatermark();
+                    if (updateGlobalWatermarkForIdleSubtask) {
+                        globalWatermark = watermarkTracker.getWatermark();
+                    }
                     LOG.info(
                             "WatermarkSyncCallback subtask: {} is idle",
                             indexOfThisConsumerSubtask);
@@ -1277,13 +1304,15 @@ public class KinesisDataFetcher<T> {
                     lastLogged = System.currentTimeMillis();
                     LOG.info(
                             "WatermarkSyncCallback subtask: {} local watermark: {}"
-                                    + ", global watermark: {}, delta: {} timeouts: {}, emitter: {}",
+                                    + ", global watermark: {}, delta: {} timeouts: {}, emitter: {}"
+                                    + ", idle: {}",
                             indexOfThisConsumerSubtask,
                             nextWatermark,
                             globalWatermark,
                             nextWatermark - globalWatermark,
                             watermarkTracker.getUpdateTimeoutCount(),
-                            recordEmitter.printInfo());
+                            recordEmitter.printInfo(),
+                            isIdle);
 
                     // Following is for debugging non-reproducible issue with stalled watermark
                     if (globalWatermark == nextWatermark

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -1304,15 +1304,15 @@ public class KinesisDataFetcher<T> {
                     lastLogged = System.currentTimeMillis();
                     LOG.info(
                             "WatermarkSyncCallback subtask: {} local watermark: {}"
-                                    + ", global watermark: {}, delta: {} timeouts: {}, emitter: {}"
-                                    + ", idle: {}",
+                                    + ", global watermark: {}, delta: {} timeouts: {}, idle: {}"
+                                    + ", emitter: {}",
                             indexOfThisConsumerSubtask,
                             nextWatermark,
                             globalWatermark,
                             nextWatermark - globalWatermark,
                             watermarkTracker.getUpdateTimeoutCount(),
-                            recordEmitter.printInfo(),
-                            isIdle);
+                            isIdle,
+                            recordEmitter.printInfo());
 
                     // Following is for debugging non-reproducible issue with stalled watermark
                     if (globalWatermark == nextWatermark

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -142,6 +142,9 @@ public class KinesisDataFetcher<T> {
     /** The metric group that all metrics should be registered to. */
     private final MetricGroup consumerMetricGroup;
 
+    /** The metric group for the individual subtask. */
+    private final MetricGroup shardMetricsGroup;
+
     // ------------------------------------------------------------------------
     //  Subtask-specific settings
     // ------------------------------------------------------------------------
@@ -415,7 +418,9 @@ public class KinesisDataFetcher<T> {
                 runtimeContext
                         .getMetricGroup()
                         .addGroup(KinesisConsumerMetricConstants.KINESIS_CONSUMER_METRICS_GROUP);
-
+        this.shardMetricsGroup =
+                consumerMetricGroup.addGroup(
+                        "subtaskId", String.valueOf(indexOfThisConsumerSubtask));
         this.error = checkNotNull(error);
         this.subscribedShardsState = checkNotNull(subscribedShardsState);
         this.subscribedStreamsToLastDiscoveredShardIds =
@@ -1213,6 +1218,7 @@ public class KinesisDataFetcher<T> {
                 isIdle = false;
             }
             nextWatermark = potentialNextWatermark;
+            shardMetricsGroup.gauge("isIdle", () -> isIdle ? 1 : 0);
         }
     }
 
@@ -1272,9 +1278,7 @@ public class KinesisDataFetcher<T> {
             this.timerService = checkNotNull(timerService);
             this.interval = interval;
             this.updateGlobalWatermarkForIdleSubtask = updateGlobalWatermarkForIdleSubtask;
-            MetricGroup shardMetricsGroup =
-                    consumerMetricGroup.addGroup(
-                            "subtaskId", String.valueOf(indexOfThisConsumerSubtask));
+
             shardMetricsGroup.gauge("localWatermark", () -> nextWatermark);
             shardMetricsGroup.gauge("globalWatermark", () -> lastGlobalWatermark);
         }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -1263,11 +1263,11 @@ public class KinesisDataFetcher<T> {
         public void onProcessingTime(long timestamp) {
             if (nextWatermark != Long.MIN_VALUE) {
                 long globalWatermark = lastGlobalWatermark;
-                // TODO: refresh watermark while idle
                 if (!(isIdle && nextWatermark == propagatedLocalWatermark)) {
                     globalWatermark = watermarkTracker.updateWatermark(nextWatermark);
                     propagatedLocalWatermark = nextWatermark;
                 } else {
+                    globalWatermark = watermarkTracker.getWatermark();
                     LOG.info(
                             "WatermarkSyncCallback subtask: {} is idle",
                             indexOfThisConsumerSubtask);

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTracker.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTracker.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.connectors.kinesis.util;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
@@ -115,8 +114,7 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
     }
 
     /** Aggregate function for computing a combined watermark of parallel subtasks. */
-    @VisibleForTesting
-    static class WatermarkAggregateFunction
+    private static class WatermarkAggregateFunction
             implements AggregateFunction<byte[], Map<String, WatermarkState>, byte[]> {
 
         private long updateTimeoutMillis = DEFAULT_UPDATE_TIMEOUT_MILLIS;

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTracker.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTracker.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.kinesis.util;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
@@ -58,6 +59,18 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
         WatermarkUpdate update = new WatermarkUpdate();
         update.id = getSubtaskId();
         update.watermark = localWatermark;
+        return updateWatermark(update);
+    }
+
+    @Override
+    public long getWatermark() {
+        WatermarkUpdate update = new WatermarkUpdate();
+        update.id = getSubtaskId();
+        update.noOp = true;
+        return updateWatermark(update);
+    }
+
+    public long updateWatermark(WatermarkUpdate update) {
         try {
             byte[] resultBytes =
                     aggregateManager.updateGlobalAggregate(
@@ -68,26 +81,6 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
                     InstantiationUtil.deserializeObject(
                             resultBytes, this.getClass().getClassLoader());
             this.updateTimeoutCount += result.updateTimeoutCount;
-            return result.watermark;
-        } catch (ClassNotFoundException | IOException ex) {
-            throw new RuntimeException(ex);
-        }
-    }
-
-    @Override
-    public long getWatermark() {
-        WatermarkUpdate update = new WatermarkUpdate();
-        update.id = getSubtaskId();
-        update.noOp = true;
-        try {
-            byte[] resultBytes =
-                    aggregateManager.updateGlobalAggregate(
-                            aggregateName,
-                            InstantiationUtil.serializeObject(update),
-                            aggregateFunction);
-            WatermarkResult result =
-                    InstantiationUtil.deserializeObject(
-                            resultBytes, this.getClass().getClassLoader());
             return result.watermark;
         } catch (ClassNotFoundException | IOException ex) {
             throw new RuntimeException(ex);
@@ -122,7 +115,8 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
     }
 
     /** Aggregate function for computing a combined watermark of parallel subtasks. */
-    private static class WatermarkAggregateFunction
+    @VisibleForTesting
+    static class WatermarkAggregateFunction
             implements AggregateFunction<byte[], Map<String, WatermarkState>, byte[]> {
 
         private long updateTimeoutMillis = DEFAULT_UPDATE_TIMEOUT_MILLIS;
@@ -161,7 +155,6 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
             }
             ws.watermark = value.watermark;
             ws.lastUpdated = System.currentTimeMillis();
-
             return accumulator;
         }
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTracker.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTracker.java
@@ -75,6 +75,26 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
     }
 
     @Override
+    public long getWatermark() {
+        WatermarkUpdate update = new WatermarkUpdate();
+        update.id = getSubtaskId();
+        update.noOp = true;
+        try {
+            byte[] resultBytes =
+                    aggregateManager.updateGlobalAggregate(
+                            aggregateName,
+                            InstantiationUtil.serializeObject(update),
+                            aggregateFunction);
+            WatermarkResult result =
+                    InstantiationUtil.deserializeObject(
+                            resultBytes, this.getClass().getClassLoader());
+            return result.watermark;
+        } catch (ClassNotFoundException | IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
     public void open(RuntimeContext context) {
         super.open(context);
         this.aggregateFunction.updateTimeoutMillis = super.getUpdateTimeoutMillis();
@@ -92,6 +112,7 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
     protected static class WatermarkUpdate implements Serializable {
         protected long watermark = Long.MIN_VALUE;
         protected String id;
+        protected boolean noOp = false;
     }
 
     /** Watermark aggregation result. */
@@ -129,12 +150,18 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
+            // no op to get global watermark without updating it
+            if (value.noOp) {
+                addCount--;
+                return accumulator;
+            }
             WatermarkState ws = accumulator.get(value.id);
             if (ws == null) {
                 accumulator.put(value.id, ws = new WatermarkState());
             }
             ws.watermark = value.watermark;
             ws.lastUpdated = System.currentTimeMillis();
+
             return accumulator;
         }
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTracker.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTracker.java
@@ -66,7 +66,7 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
     public long getWatermark() {
         WatermarkUpdate update = new WatermarkUpdate();
         update.id = getSubtaskId();
-        update.noOp = true;
+        update.updateLocalWatermark = false;
         return updateWatermark(update);
     }
 
@@ -105,7 +105,7 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
     protected static class WatermarkUpdate implements Serializable {
         protected long watermark = Long.MIN_VALUE;
         protected String id;
-        protected boolean noOp = false;
+        protected boolean updateLocalWatermark = true;
     }
 
     /** Watermark aggregation result. */
@@ -145,7 +145,7 @@ public class JobManagerWatermarkTracker extends WatermarkTracker {
                 throw new RuntimeException(e);
             }
             // no op to get global watermark without updating it
-            if (value.noOp) {
+            if (!value.updateLocalWatermark) {
                 addCount--;
                 return accumulator;
             }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTracker.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTracker.java
@@ -95,6 +95,8 @@ public abstract class WatermarkTracker implements Closeable, Serializable {
      */
     public abstract long updateWatermark(final long localWatermark);
 
+    public abstract long getWatermark();
+
     protected long getCurrentTime() {
         return System.currentTimeMillis();
     }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
@@ -1256,6 +1256,11 @@ public class FlinkKinesisConsumerTest extends TestLogger {
             return localWatermark;
         }
 
+        @Override
+        public long getWatermark() {
+            return WATERMARK.get();
+        }
+
         static void assertGlobalWatermark(long expected) {
             Assert.assertEquals(expected, WATERMARK.get());
         }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTrackerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTrackerTest.java
@@ -93,6 +93,9 @@ public class JobManagerWatermarkTrackerTest {
         public void run(SourceContext<Integer> ctx) {
             Assert.assertEquals(998, tracker.updateWatermark(998));
             Assert.assertEquals(999, tracker.updateWatermark(999));
+            Assert.assertEquals(999, tracker.getWatermark());
+            Assert.assertEquals(1000, tracker.updateWatermark(1000));
+            Assert.assertEquals(1000, tracker.getWatermark());
         }
 
         @Override

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTrackerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTrackerTest.java
@@ -71,6 +71,32 @@ public class WatermarkTrackerTest {
             return globalWatermark;
         }
 
+        @Override
+        public long getWatermark() {
+            refreshWatermarkSnapshot(this.watermarks);
+
+            long currentTime = getCurrentTime();
+            String subtaskId = this.getSubtaskId();
+
+            WatermarkState ws = watermarks.get(subtaskId);
+            if (ws == null) {
+                watermarks.put(subtaskId, ws = new WatermarkState());
+            }
+            saveWatermark(subtaskId, ws);
+
+            long globalWatermark = ws.watermark;
+            for (Map.Entry<String, WatermarkState> e : watermarks.entrySet()) {
+                ws = e.getValue();
+                if (ws.lastUpdated + getUpdateTimeoutMillis() < currentTime) {
+                    // ignore outdated subtask
+                    updateTimeoutCount++;
+                    continue;
+                }
+                globalWatermark = Math.min(ws.watermark, globalWatermark);
+            }
+            return globalWatermark;
+        }
+
         protected void refreshWatermarkSnapshot(Map<String, WatermarkState> watermarks) {
             watermarks.put("wm1", wm1);
         }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTrackerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTrackerTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /** Test for {@link WatermarkTracker}. */
 public class WatermarkTrackerTest {
@@ -45,34 +46,15 @@ public class WatermarkTrackerTest {
 
         @Override
         public long updateWatermark(final long localWatermark) {
-            refreshWatermarkSnapshot(this.watermarks);
-
-            long currentTime = getCurrentTime();
-            String subtaskId = this.getSubtaskId();
-
-            WatermarkState ws = watermarks.get(subtaskId);
-            if (ws == null) {
-                watermarks.put(subtaskId, ws = new WatermarkState());
-            }
-            ws.lastUpdated = currentTime;
-            ws.watermark = Math.max(ws.watermark, localWatermark);
-            saveWatermark(subtaskId, ws);
-
-            long globalWatermark = ws.watermark;
-            for (Map.Entry<String, WatermarkState> e : watermarks.entrySet()) {
-                ws = e.getValue();
-                if (ws.lastUpdated + getUpdateTimeoutMillis() < currentTime) {
-                    // ignore outdated subtask
-                    updateTimeoutCount++;
-                    continue;
-                }
-                globalWatermark = Math.min(ws.watermark, globalWatermark);
-            }
-            return globalWatermark;
+            return updateWatermark(Optional.of(localWatermark));
         }
 
         @Override
         public long getWatermark() {
+            return updateWatermark(Optional.empty());
+        }
+
+        private long updateWatermark(Optional<Long> localWatermark) {
             refreshWatermarkSnapshot(this.watermarks);
 
             long currentTime = getCurrentTime();
@@ -81,6 +63,11 @@ public class WatermarkTrackerTest {
             WatermarkState ws = watermarks.get(subtaskId);
             if (ws == null) {
                 watermarks.put(subtaskId, ws = new WatermarkState());
+            }
+            // empty if getting without updating
+            if (localWatermark.isPresent()) {
+                ws.lastUpdated = currentTime;
+                ws.watermark = Math.max(ws.watermark, localWatermark.get());
             }
             saveWatermark(subtaskId, ws);
 


### PR DESCRIPTION
## overview
Update the global watermark for idle subtasks. This will avoid a deadlock state by enabling the RecordEmitter to emit records that were previously stuck in the emitQueue due to the lookahead. Emitting a record from the source will enable us to no longer be marked idle in the PeriodicWatermarkEmitter.

## additional info
To get the global watermark, we need to communicate with the JM. The JobManagerWatermarkTracker is a WatermarkTracker that uses a GlobalAggregateManager to do so. This interface has 1 method updateGlobalAggregate. In order to get the global watermark without updating with the local watermark, and thus holding other subtasks back, we've modified the WatermarkAggregateFunction used by the GlobalAggregateManager to avoid updating the watermark value and lastUpdated value for the subtask by indicating a noOp field. Thus, when calculating the global watermark, the accumulator has not been modified.



*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
