### PR TITLE
[STRMCMP-1607] Relaxing the numpy version

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -305,7 +305,7 @@ try:
         install_requires=['py4j>=0.10.8.1,<=0.10.9.5', 'python-dateutil>=2.8.1', 'apache-beam==2.30.0+lyft202205161652748117',
                           'cloudpickle>=1.2.2', 'avro-python3>=1.8.1,!=1.9.2,<1.10.0',
                           'pandas>=1.0,<1.2.0', 'pyarrow>=0.15.1,<=8.0.0',
-                          'pytz>=2018.3', 'numpy>=1.14.3,<1.20', 'fastavro>=0.21.4,<0.24',
+                          'pytz>=2018.3', 'numpy>=1.14.3,<1.22.0', 'fastavro>=0.21.4,<0.24',
                           apache_flink_libraries_dependency],
         cmdclass={'build_ext': build_ext},
         tests_require=['pytest==4.4.1'],


### PR DESCRIPTION
Based on STRMCMP-1607 this PR relaxes the version of numpy.
Pinning it to `< 1.22.0` because higher versions require `python >=3.8`