### PR TITLE
Update setup.py

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -305,7 +305,7 @@ try:
         install_requires=['py4j>=0.10.8.1,<=0.10.9.5', 'python-dateutil>=2.8.1', 'apache-beam==2.30.0+lyft202205161652748117',
                           'cloudpickle>=1.2.2', 'avro-python3>=1.8.1,!=1.9.2,<1.10.0',
                           'pandas>=1.0,<1.4.0', 'pyarrow>=0.15.1,<=8.0.0',
-                          'pytz>=2018.3', 'numpy>=1.14.3,<1.22.0', 'fastavro>=0.21.4,<0.24',
+                          'pytz>=2018.3', 'numpy>=1.14.3,<1.24.0', 'fastavro>=0.21.4,<0.24',
                           apache_flink_libraries_dependency],
         cmdclass={'build_ext': build_ext},
         tests_require=['pytest==4.4.1'],


### PR DESCRIPTION
Looking at what it would take to support Flight Aware Models.
First non-starter I run into is an inability to install alongside the library which contains the models.
Log:
```
numpy<1.24,>=1.23 (from lyft_marketsignals_forecasting_models==0.2.8->-r requirements.in (line 16))
```