### PR TITLE
[STRMCMP-1659] Kinesis AWS SDK Upgrade for PIW

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -34,6 +34,7 @@ under the License.
 	<name>Flink : Connectors : Kinesis</name>
 	<properties>
 		<aws.sdk.version>1.11.788</aws.sdk.version>
+
 		<aws.sdkv2.version>2.16.86</aws.sdkv2.version>
 		<aws.kinesis-kcl.version>1.11.2</aws.kinesis-kcl.version>
 		<aws.kinesis-kpl.version>0.14.0</aws.kinesis-kpl.version>

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	<artifactId>flink-connector-kinesis_${scala.binary.version}</artifactId>
 	<name>Flink : Connectors : Kinesis</name>
 	<properties>
-		<aws.sdk.version>1.11.603</aws.sdk.version>
+		<aws.sdk.version>1.11.788</aws.sdk.version>
 		<aws.sdkv2.version>2.16.86</aws.sdkv2.version>
 		<aws.kinesis-kcl.version>1.11.2</aws.kinesis-kcl.version>
 		<aws.kinesis-kpl.version>0.14.0</aws.kinesis-kpl.version>

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -34,7 +34,6 @@ under the License.
 	<name>Flink : Connectors : Kinesis</name>
 	<properties>
 		<aws.sdk.version>1.11.788</aws.sdk.version>
-
 		<aws.sdkv2.version>2.16.86</aws.sdkv2.version>
 		<aws.kinesis-kcl.version>1.11.2</aws.kinesis-kcl.version>
 		<aws.kinesis-kpl.version>0.14.0</aws.kinesis-kpl.version>


### PR DESCRIPTION
## overview
AWS SDK >1.11.704 required for kiam -> PIW. Version was previously [downgraded here](https://github.com/lyft/flink/commit/f9a1a9184ce16ee3e45a71549efbeabb323012e8) after seeing failing tests on flinkperf. Keeping the version on 1.11.x for that reason but upgrading to >1.11.704. Matching the version to 1.11.788 used in other places in flink 1.13
