### PR TITLE
[FLINK-32414][connectors/common] Don't emitLatestWatermark when lastEmittedWatermark is UNINITIALIZED

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -503,6 +503,9 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
 
     private void emitLatestWatermark(long time) {
         checkState(currentMainOutput != null);
+        if (lastEmittedWatermark == Watermark.UNINITIALIZED.getTimestamp()) {
+            return;
+        }
         operatorEventGateway.sendEventToCoordinator(
                 new ReportedWatermarkEvent(lastEmittedWatermark));
     }


### PR DESCRIPTION
When enabling watermark alignment, I'm seeing this issue where the uninitialized watermark is being propagated. This pulls in an upstream change to address this issue.

Upstream change: https://github.com/apache/flink/pull/22847
Context: https://issues.apache.org/jira/browse/FLINK-32414
