### PR TITLE
Cherrypick of parallel checkpoint deletion change

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -27,6 +27,12 @@
             <td>The checkpoint storage implementation to be used to checkpoint state.<br />The implementation can be specified either via their shortcut  name, or via the class name of a <code class="highlighter-rouge">CheckpointStorageFactory</code>. If a factory is specified it is instantiated via its zero argument constructor and its <code class="highlighter-rouge">CheckpointStorageFactory#createFromConfig(ReadableConfig, ClassLoader)</code>  method is called.<br />Recognized shortcut names are 'jobmanager' and 'filesystem'.</td>
         </tr>
         <tr>
+            <td><h5>state.checkpoint.cleaner.parallel-mode</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Option whether to discard a checkpoint's states in parallel using the ExecutorService passed into the cleaner</td>
+        </tr>
+        <tr>
             <td><h5>state.checkpoints.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/common_state_backends_section.html
+++ b/docs/layouts/shortcodes/generated/common_state_backends_section.html
@@ -45,6 +45,12 @@
             <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).</td>
         </tr>
         <tr>
+            <td><h5>state.checkpoint.cleaner.parallel-mode</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Option whether to discard a checkpoint's states in parallel using the ExecutorService passed into the cleaner</td>
+        </tr>
+        <tr>
             <td><h5>state.checkpoints.num-retained</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -109,6 +109,19 @@ public class CheckpointingOptions {
                     .defaultValue(1)
                     .withDescription("The maximum number of completed checkpoints to retain.");
 
+    /* Option whether to clean individual checkpoint's operatorstates in parallel. If enabled,
+     * operator states are discarded in parallel using the ExecutorService passed to the cleaner.
+     * This speeds up checkpoints cleaning, but adds load to the IO.
+     */
+    @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
+    public static final ConfigOption<Boolean> CLEANER_PARALLEL_MODE =
+            ConfigOptions.key("state.checkpoint.cleaner.parallel-mode")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Option whether to discard a checkpoint's states in parallel using"
+                                    + " the ExecutorService passed into the cleaner");
+
     /** @deprecated Checkpoints are always asynchronous. */
     @Deprecated
     public static final ConfigOption<Boolean> ASYNC_SNAPSHOTS =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoint.java
@@ -17,6 +17,11 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 /** A checkpoint, pending or completed. */
 public interface Checkpoint {
     DiscardObject NOOP_DISCARD_OBJECT = () -> {};
@@ -33,5 +38,9 @@ public interface Checkpoint {
     /** Extra interface for discarding the checkpoint. */
     interface DiscardObject {
         void discard() throws Exception;
+
+        default CompletableFuture<Void> discardAsync(Executor ioExecutor) {
+            return FutureUtils.runAsync(this::discard, ioExecutor);
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -25,9 +25,12 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.FutureUtils.ConjunctFuture;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +46,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -327,7 +333,6 @@ public class CompletedCheckpoint implements Serializable, Checkpoint {
     /** Implementation of {@link org.apache.flink.runtime.checkpoint.Checkpoint.DiscardObject}. */
     @NotThreadSafe
     public class CompletedCheckpointDiscardObject implements DiscardObject {
-
         @Override
         public void discard() throws Exception {
             LOG.trace("Executing discard procedure for {}.", this);
@@ -370,6 +375,35 @@ public class CompletedCheckpoint implements Serializable, Checkpoint {
 
         private boolean isMarkedAsDiscarded() {
             return completedCheckpointStats == null || completedCheckpointStats.isDiscarded();
+        }
+
+        @Override
+        public CompletableFuture<Void> discardAsync(Executor ioExecutor) {
+            checkState(
+                    isMarkedAsDiscarded(),
+                    "Checkpoint should be marked as discarded before discard.");
+
+            List<StateObject> discardables =
+                    operatorStates.values().stream()
+                            .flatMap(op -> op.getDiscardables().stream())
+                            .collect(Collectors.toList());
+            discardables.add(metadataHandle);
+
+            ConjunctFuture<Void> discardStates =
+                    FutureUtils.completeAll(
+                            discardables.stream()
+                                    .map(
+                                            item ->
+                                                    FutureUtils.runAsync(
+                                                            item::discardState, ioExecutor))
+                                    .collect(Collectors.toList()));
+
+            return FutureUtils.runAfterwards(
+                    discardStates,
+                    () -> {
+                        operatorStates.clear();
+                        storageLocation.disposeStorageLocation();
+                    });
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CompositeStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.Preconditions;
 
@@ -29,8 +30,10 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -163,6 +166,18 @@ public class OperatorState implements CompositeStateHandle {
         }
 
         return newState;
+    }
+
+    public List<StateObject> getDiscardables() {
+        List<StateObject> toDispose =
+                operatorSubtaskStates.values().stream()
+                        .flatMap(op -> op.getDiscardables().stream())
+                        .collect(Collectors.toList());
+
+        if (coordinatorState != null) {
+            toDispose.add(coordinatorState);
+        }
+        return toDispose;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
@@ -194,22 +194,27 @@ public class OperatorSubtaskState implements CompositeStateHandle {
         return outputRescalingDescriptor;
     }
 
+    public List<StateObject> getDiscardables() {
+        List<StateObject> toDispose =
+                new ArrayList<>(
+                        managedOperatorState.size()
+                                + rawOperatorState.size()
+                                + managedKeyedState.size()
+                                + rawKeyedState.size()
+                                + inputChannelState.size()
+                                + resultSubpartitionState.size());
+        toDispose.addAll(managedOperatorState);
+        toDispose.addAll(rawOperatorState);
+        toDispose.addAll(managedKeyedState);
+        toDispose.addAll(rawKeyedState);
+        toDispose.addAll(collectUniqueDelegates(inputChannelState, resultSubpartitionState));
+        return toDispose;
+    }
+
     @Override
     public void discardState() {
         try {
-            List<StateObject> toDispose =
-                    new ArrayList<>(
-                            managedOperatorState.size()
-                                    + rawOperatorState.size()
-                                    + managedKeyedState.size()
-                                    + rawKeyedState.size()
-                                    + inputChannelState.size()
-                                    + resultSubpartitionState.size());
-            toDispose.addAll(managedOperatorState);
-            toDispose.addAll(rawOperatorState);
-            toDispose.addAll(managedKeyedState);
-            toDispose.addAll(rawKeyedState);
-            toDispose.addAll(collectUniqueDelegates(inputChannelState, resultSubpartitionState));
+            List<StateObject> toDispose = getDiscardables();
             StateUtil.bestEffortDiscardAllStateObjects(toDispose);
         } catch (Exception e) {
             LOG.warn("Error while discarding operator states.", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -29,10 +29,13 @@ import org.apache.flink.runtime.operators.coordination.OperatorInfo;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.FutureUtils.ConjunctFuture;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +55,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -646,6 +650,40 @@ public class PendingCheckpoint implements Checkpoint {
             } finally {
                 operatorStates.clear();
             }
+        }
+
+        @Override
+        public CompletableFuture<Void> discardAsync(Executor ioExecutor) {
+            synchronized (lock) {
+                if (discarded) {
+                    Preconditions.checkState(
+                            disposed, "Checkpoint should be disposed before being discarded");
+                } else {
+                    discarded = true;
+                }
+            }
+            List<StateObject> discardables =
+                    operatorStates.values().stream()
+                            .flatMap(op -> op.getDiscardables().stream())
+                            .collect(Collectors.toList());
+
+            ConjunctFuture<Void> discardStates =
+                    FutureUtils.completeAll(
+                            discardables.stream()
+                                    .map(
+                                            item ->
+                                                    FutureUtils.runAsync(
+                                                            item::discardState, ioExecutor))
+                                    .collect(Collectors.toList()));
+
+            return FutureUtils.runAfterwards(
+                    discardStates,
+                    () -> {
+                        operatorStates.clear();
+                        if (targetLocation != null) {
+                            targetLocation.disposeOnFailure();
+                        }
+                    });
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunner.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.dispatcher.cleanup;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
@@ -88,7 +89,10 @@ public class CheckpointResourcesCleanupRunner implements JobManagerRunner {
         this.cleanupExecutor = Preconditions.checkNotNull(cleanupExecutor);
         this.initializationTimestamp = initializationTimestamp;
 
-        this.checkpointsCleaner = new CheckpointsCleaner();
+        this.checkpointsCleaner =
+                new CheckpointsCleaner(
+                        jobManagerConfiguration.getBoolean(
+                                CheckpointingOptions.CLEANER_PARALLEL_MODE));
 
         this.resultFuture = new CompletableFuture<>();
         this.cleanupFuture = resultFuture.thenCompose(ignored -> runCleanupAsync());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.blob.BlobWriter;
@@ -119,6 +120,11 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
                         shuffleMaster,
                         partitionTracker);
 
+        final CheckpointsCleaner checkpointsCleaner =
+                new CheckpointsCleaner(
+                        jobMasterConfiguration.getBoolean(
+                                CheckpointingOptions.CLEANER_PARALLEL_MODE));
+
         return new DefaultScheduler(
                 log,
                 jobGraph,
@@ -127,7 +133,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
                 schedulerComponents.getStartUpAction(),
                 new ScheduledExecutorServiceAdapter(futureExecutor),
                 userCodeLoader,
-                new CheckpointsCleaner(),
+                checkpointsCleaner,
                 checkpointRecoveryFactory,
                 jobManagerJobMetricGroup,
                 schedulerComponents.getSchedulingStrategyFactory(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -171,7 +171,6 @@ class CheckpointCoordinatorFailureTest extends TestLogger {
         assertThat(pendingCheckpoint.isDisposed()).isTrue();
 
         // make sure that the subtask state has been discarded after we could not complete it.
-        verify(operatorSubtaskState).discardState();
         verify(operatorSubtaskState.getManagedOperatorState().iterator().next()).discardState();
         verify(operatorSubtaskState.getRawOperatorState().iterator().next()).discardState();
         verify(operatorSubtaskState.getManagedKeyedState().iterator().next()).discardState();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.execution.SavepointFormatType;
+import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -56,6 +57,7 @@ import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.PhysicalStateHandleID;
 import org.apache.flink.runtime.state.PlaceholderStreamStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateHandleID;
@@ -1514,9 +1516,12 @@ class CheckpointCoordinatorTest extends TestLogger {
         TaskStateSnapshot taskOperatorSubtaskStates12 = spy(new TaskStateSnapshot());
         TaskStateSnapshot taskOperatorSubtaskStates13 = spy(new TaskStateSnapshot());
 
-        OperatorSubtaskState subtaskState11 = mock(OperatorSubtaskState.class);
-        OperatorSubtaskState subtaskState12 = mock(OperatorSubtaskState.class);
-        OperatorSubtaskState subtaskState13 = mock(OperatorSubtaskState.class);
+        OperatorSubtaskStateMock subtaskState11mock = new OperatorSubtaskStateMock();
+        OperatorSubtaskStateMock subtaskState12mock = new OperatorSubtaskStateMock();
+        OperatorSubtaskStateMock subtaskState13mock = new OperatorSubtaskStateMock();
+        OperatorSubtaskState subtaskState11 = subtaskState11mock.getSubtaskState();
+        OperatorSubtaskState subtaskState12 = subtaskState12mock.getSubtaskState();
+        OperatorSubtaskState subtaskState13 = subtaskState13mock.getSubtaskState();
         taskOperatorSubtaskStates11.putSubtaskStateByOperatorID(opID1, subtaskState11);
         taskOperatorSubtaskStates12.putSubtaskStateByOperatorID(opID2, subtaskState12);
         taskOperatorSubtaskStates13.putSubtaskStateByOperatorID(opID3, subtaskState13);
@@ -1555,9 +1560,12 @@ class CheckpointCoordinatorTest extends TestLogger {
         TaskStateSnapshot taskOperatorSubtaskStates22 = spy(new TaskStateSnapshot());
         TaskStateSnapshot taskOperatorSubtaskStates23 = spy(new TaskStateSnapshot());
 
-        OperatorSubtaskState subtaskState21 = mock(OperatorSubtaskState.class);
-        OperatorSubtaskState subtaskState22 = mock(OperatorSubtaskState.class);
-        OperatorSubtaskState subtaskState23 = mock(OperatorSubtaskState.class);
+        OperatorSubtaskStateMock subtaskState21mock = new OperatorSubtaskStateMock();
+        OperatorSubtaskStateMock subtaskState22mock = new OperatorSubtaskStateMock();
+        OperatorSubtaskStateMock subtaskState23mock = new OperatorSubtaskStateMock();
+        OperatorSubtaskState subtaskState21 = subtaskState21mock.getSubtaskState();
+        OperatorSubtaskState subtaskState22 = subtaskState22mock.getSubtaskState();
+        OperatorSubtaskState subtaskState23 = subtaskState23mock.getSubtaskState();
 
         taskOperatorSubtaskStates21.putSubtaskStateByOperatorID(opID1, subtaskState21);
         taskOperatorSubtaskStates22.putSubtaskStateByOperatorID(opID2, subtaskState22);
@@ -1619,13 +1627,13 @@ class CheckpointCoordinatorTest extends TestLogger {
         assertThat(checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints()).isOne();
 
         // validate that all received subtask states in the first checkpoint have been discarded
-        verify(subtaskState11, times(1)).discardState();
-        verify(subtaskState12, times(1)).discardState();
+        subtaskState11mock.verifyDiscard();
+        subtaskState12mock.verifyDiscard();
 
         // validate that all subtask states in the second checkpoint are not discarded
-        verify(subtaskState21, never()).discardState();
-        verify(subtaskState22, never()).discardState();
-        verify(subtaskState23, never()).discardState();
+        subtaskState21mock.verifyNotDiscard();
+        subtaskState22mock.verifyNotDiscard();
+        subtaskState23mock.verifyNotDiscard();
 
         // validate the committed checkpoints
         List<CompletedCheckpoint> scs = checkpointCoordinator.getSuccessfulCheckpoints();
@@ -1650,15 +1658,15 @@ class CheckpointCoordinatorTest extends TestLogger {
                         new CheckpointMetrics(),
                         taskOperatorSubtaskStates13),
                 TASK_MANAGER_LOCATION_INFO);
-        verify(subtaskState13, times(1)).discardState();
+        subtaskState13mock.verifyDiscard();
 
         checkpointCoordinator.shutdown();
         completedCheckpointStore.shutdown(JobStatus.FINISHED, new CheckpointsCleaner());
 
         // validate that the states in the second checkpoint have been discarded
-        verify(subtaskState21, times(1)).discardState();
-        verify(subtaskState22, times(1)).discardState();
-        verify(subtaskState23, times(1)).discardState();
+        subtaskState21mock.verifyDiscard();
+        subtaskState22mock.verifyDiscard();
+        subtaskState23mock.verifyDiscard();
     }
 
     @Test
@@ -1702,7 +1710,8 @@ class CheckpointCoordinatorTest extends TestLogger {
         OperatorID opID1 = vertex1.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
 
         TaskStateSnapshot taskOperatorSubtaskStates1 = spy(new TaskStateSnapshot());
-        OperatorSubtaskState subtaskState1 = mock(OperatorSubtaskState.class);
+        OperatorSubtaskStateMock operatorSubtaskStateMock = new OperatorSubtaskStateMock();
+        OperatorSubtaskState subtaskState1 = operatorSubtaskStateMock.getSubtaskState();
         taskOperatorSubtaskStates1.putSubtaskStateByOperatorID(opID1, subtaskState1);
 
         checkpointCoordinator.receiveAcknowledgeMessage(
@@ -1721,9 +1730,7 @@ class CheckpointCoordinatorTest extends TestLogger {
                 .isTrue();
         assertThat(checkpointCoordinator.getNumberOfPendingCheckpoints()).isZero();
         assertThat(checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints()).isZero();
-
-        // validate that the received states have been discarded
-        verify(subtaskState1, times(1)).discardState();
+        operatorSubtaskStateMock.verifyDiscard();
 
         // no confirm message must have been sent
         for (ExecutionVertex vertex : Arrays.asList(vertex1, vertex2)) {
@@ -1846,7 +1853,8 @@ class CheckpointCoordinatorTest extends TestLogger {
                 vertex1.getJobVertex().getOperatorIDs().get(0).getGeneratedOperatorID();
 
         TaskStateSnapshot taskOperatorSubtaskStatesTrigger = spy(new TaskStateSnapshot());
-        OperatorSubtaskState subtaskStateTrigger = mock(OperatorSubtaskState.class);
+        OperatorSubtaskStateMock subtaskStateMock = new OperatorSubtaskStateMock();
+        OperatorSubtaskState subtaskStateTrigger = subtaskStateMock.getSubtaskState();
         taskOperatorSubtaskStatesTrigger.putSubtaskStateByOperatorID(
                 opIDtrigger, subtaskStateTrigger);
 
@@ -1861,7 +1869,7 @@ class CheckpointCoordinatorTest extends TestLogger {
                 TASK_MANAGER_LOCATION_INFO);
 
         // verify that the subtask state has not been discarded
-        verify(subtaskStateTrigger, never()).discardState();
+        subtaskStateMock.verifyNotDiscard();
 
         TaskStateSnapshot unknownSubtaskState = mock(TaskStateSnapshot.class);
 
@@ -1908,7 +1916,7 @@ class CheckpointCoordinatorTest extends TestLogger {
         verify(triggerSubtaskState, never()).discardState();
 
         // let the checkpoint fail at the first ack vertex
-        reset(subtaskStateTrigger);
+        subtaskStateMock.reset();
         checkpointCoordinator.receiveDeclineMessage(
                 new DeclineCheckpoint(
                         graph.getJobID(),
@@ -1920,7 +1928,7 @@ class CheckpointCoordinatorTest extends TestLogger {
         assertThat(pendingCheckpoint.isDisposed()).isTrue();
 
         // check that we've cleaned up the already acknowledged state
-        verify(subtaskStateTrigger, times(1)).discardState();
+        subtaskStateMock.verifyDiscard();
 
         TaskStateSnapshot ackSubtaskState = mock(TaskStateSnapshot.class);
 
@@ -4169,5 +4177,89 @@ class CheckpointCoordinatorTest extends TestLogger {
                                                                 metaState))
                                                 .build()))),
                 "test");
+    }
+
+    static class OperatorSubtaskStateMock {
+        OperatorSubtaskState subtaskState;
+        TestingOperatorStateHandle managedOpHandle;
+        TestingOperatorStateHandle rawOpHandle;
+
+        OperatorSubtaskStateMock() {
+            this.managedOpHandle = new TestingOperatorStateHandle();
+            this.rawOpHandle = new TestingOperatorStateHandle();
+            this.subtaskState =
+                    OperatorSubtaskState.builder()
+                            .setManagedOperatorState(managedOpHandle)
+                            .setRawOperatorState(rawOpHandle)
+                            .build();
+        }
+
+        public OperatorSubtaskState getSubtaskState() {
+            return this.subtaskState;
+        }
+
+        public void reset() {
+            managedOpHandle.reset();
+            rawOpHandle.reset();
+        }
+
+        public void verifyDiscard() {
+            assert (managedOpHandle.isDiscarded() && rawOpHandle.discarded);
+        }
+
+        public void verifyNotDiscard() {
+            assert (!managedOpHandle.isDiscarded() && !rawOpHandle.isDiscarded());
+        }
+
+        private static class TestingOperatorStateHandle implements OperatorStateHandle {
+
+            private static final long serialVersionUID = 983594934287613083L;
+
+            boolean discarded;
+
+            @Override
+            public Map<String, StateMetaInfo> getStateNameToPartitionOffsets() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public FSDataInputStream openInputStream() throws IOException {
+                throw new IOException("Cannot open input streams in testing implementation.");
+            }
+
+            @Override
+            public PhysicalStateHandleID getStreamStateHandleID() {
+                throw new RuntimeException("Cannot return ID in testing implementation.");
+            }
+
+            @Override
+            public Optional<byte[]> asBytesIfInMemory() {
+                return Optional.empty();
+            }
+
+            @Override
+            public StreamStateHandle getDelegateStateHandle() {
+                return null;
+            }
+
+            @Override
+            public void discardState() throws Exception {
+                assertThat(discarded).isFalse();
+                discarded = true;
+            }
+
+            @Override
+            public long getStateSize() {
+                return 0L;
+            }
+
+            public void reset() {
+                discarded = false;
+            }
+
+            public boolean isDiscarded() {
+                return discarded;
+            }
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -279,7 +280,7 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
     /**
      * A test {@link CompletedCheckpoint}. We want to verify that the correct class loader is used
      * when discarding. Spying on a regular {@link CompletedCheckpoint} instance with Mockito
-     * doesn't work, because it it breaks serializability.
+     * doesn't work, because it breaks serializability.
      */
     protected static class TestCompletedCheckpoint extends CompletedCheckpoint {
 
@@ -334,8 +335,12 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             TestCompletedCheckpoint that = (TestCompletedCheckpoint) o;
 
@@ -353,6 +358,15 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
             @Override
             public void discard() throws Exception {
                 super.discard();
+                updateDiscards();
+            }
+
+            @Override
+            public CompletableFuture<Void> discardAsync(Executor executor) {
+                return super.discardAsync(executor).thenRun(this::updateDiscards);
+            }
+
+            private void updateDiscards() {
                 if (!isDiscarded) {
                     isDiscarded = true;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FullyFinishedOperatorStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FullyFinishedOperatorStateTest.java
@@ -18,7 +18,11 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.InputChannelStateHandle;
+import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
 import org.junit.Test;
@@ -26,6 +30,13 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.generateSampleOperatorSubtaskState;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
 
 /** Tests the properties of {@link FullyFinishedOperatorState}. */
 public class FullyFinishedOperatorStateTest {
@@ -53,5 +64,31 @@ public class FullyFinishedOperatorStateTest {
         } catch (UnsupportedOperationException e) {
             // Excepted
         }
+    }
+
+    @Test
+    void testGetDiscardables() throws IOException {
+        Tuple2<List<StateObject>, OperatorSubtaskState> opSubtaskStates1 =
+                generateSampleOperatorSubtaskState();
+        Tuple2<List<StateObject>, OperatorSubtaskState> opSubtaskStates2 =
+                generateSampleOperatorSubtaskState();
+
+        OperatorState operatorState = new OperatorState(new OperatorID(), 2, 256);
+        operatorState.putState(0, opSubtaskStates1.f1);
+        operatorState.putState(1, opSubtaskStates2.f1);
+        ByteStreamStateHandle coordinatorState =
+                new ByteStreamStateHandle("test", new byte[] {1, 2, 3, 4});
+        operatorState.setCoordinatorState(coordinatorState);
+        HashSet<StateObject> discardables = new HashSet<>();
+        discardables.addAll(opSubtaskStates1.f0.subList(0, 4));
+        discardables.add(((InputChannelStateHandle) opSubtaskStates1.f0.get(4)).getDelegate());
+        discardables.add(
+                ((ResultSubpartitionStateHandle) opSubtaskStates1.f0.get(5)).getDelegate());
+        discardables.addAll(opSubtaskStates2.f0.subList(0, 4));
+        discardables.add(((InputChannelStateHandle) opSubtaskStates2.f0.get(4)).getDelegate());
+        discardables.add(
+                ((ResultSubpartitionStateHandle) opSubtaskStates2.f0.get(5)).getDelegate());
+        discardables.add(coordinatorState);
+        assertThat(new HashSet<>(operatorState.getDiscardables())).isEqualTo(discardables);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskStateTest.java
@@ -17,20 +17,18 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.state.InputChannelStateHandle;
-import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Random;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -65,37 +63,7 @@ public class OperatorSubtaskStateTest {
     @Test
     public void testToBuilderCorrectness() throws IOException {
         // given: Initialized operator subtask state.
-        JobVertexID jobVertexID = new JobVertexID();
-        int index = 0;
-        Random random = new Random();
-
-        OperatorSubtaskState operatorSubtaskState =
-                OperatorSubtaskState.builder()
-                        .setManagedOperatorState(
-                                generatePartitionableStateHandle(jobVertexID, index, 2, 8, false))
-                        .setRawOperatorState(
-                                generatePartitionableStateHandle(jobVertexID, index, 2, 8, true))
-                        .setManagedKeyedState(
-                                generateKeyGroupState(jobVertexID, new KeyGroupRange(0, 11), false))
-                        .setRawKeyedState(
-                                generateKeyGroupState(jobVertexID, new KeyGroupRange(0, 9), true))
-                        .setInputChannelState(
-                                StateObjectCollection.singleton(
-                                        createNewInputChannelStateHandle(3, random)))
-                        .setResultSubpartitionState(
-                                StateObjectCollection.singleton(
-                                        createNewResultSubpartitionStateHandle(3, random)))
-                        .setInputRescalingDescriptor(
-                                InflightDataRescalingDescriptorUtil.rescalingDescriptor(
-                                        new int[1],
-                                        new RescaleMappings[0],
-                                        Collections.singleton(1)))
-                        .setOutputRescalingDescriptor(
-                                InflightDataRescalingDescriptorUtil.rescalingDescriptor(
-                                        new int[1],
-                                        new RescaleMappings[0],
-                                        Collections.singleton(2)))
-                        .build();
+        OperatorSubtaskState operatorSubtaskState = generateSampleOperatorSubtaskState().f1;
 
         // when: Copy the operator subtask state.
         OperatorSubtaskState operatorSubtaskStateCopy = operatorSubtaskState.toBuilder().build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTest.OperatorSubtaskStateMock;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.StringSerializer;
 import org.apache.flink.runtime.checkpoint.PendingCheckpoint.TaskAcknowledgeResult;
 import org.apache.flink.runtime.checkpoint.hooks.MasterHooks;
@@ -35,7 +36,6 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorInfo;
 import org.apache.flink.runtime.operators.coordination.TestingOperatorInfo;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
-import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.TestingStreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStorageLocation;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
@@ -44,7 +44,6 @@ import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 
@@ -66,11 +65,7 @@ import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.cr
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -230,8 +225,10 @@ class PendingCheckpointTest {
                         false, CheckpointType.CHECKPOINT, false, false, false, false, false, false);
         QueueExecutor executor = new QueueExecutor();
 
-        OperatorState state = mock(OperatorState.class);
-        doNothing().when(state).registerSharedStates(any(SharedStateRegistry.class), eq(0L));
+        OperatorState state = new OperatorState(new OperatorID(), 1, 256);
+        OperatorSubtaskStateMock subtaskStateMock = new OperatorSubtaskStateMock();
+        OperatorSubtaskState subtaskState = subtaskStateMock.getSubtaskState();
+        state.putState(0, subtaskState);
 
         // Abort declined
         PendingCheckpoint pending = createPendingCheckpoint(props, executor);
@@ -240,10 +237,10 @@ class PendingCheckpointTest {
         abort(pending, CheckpointFailureReason.CHECKPOINT_DECLINED);
         // execute asynchronous discard operation
         executor.runQueuedCommands();
-        verify(state, times(1)).discardState();
+        subtaskStateMock.verifyDiscard();
 
         // Abort error
-        Mockito.reset(state);
+        subtaskStateMock.reset();
 
         pending = createPendingCheckpoint(props, executor);
         setTaskState(pending, state);
@@ -251,10 +248,10 @@ class PendingCheckpointTest {
         abort(pending, CheckpointFailureReason.CHECKPOINT_DECLINED);
         // execute asynchronous discard operation
         executor.runQueuedCommands();
-        verify(state, times(1)).discardState();
+        subtaskStateMock.verifyDiscard();
 
         // Abort expired
-        Mockito.reset(state);
+        subtaskStateMock.reset();
 
         pending = createPendingCheckpoint(props, executor);
         setTaskState(pending, state);
@@ -262,10 +259,10 @@ class PendingCheckpointTest {
         abort(pending, CheckpointFailureReason.CHECKPOINT_EXPIRED);
         // execute asynchronous discard operation
         executor.runQueuedCommands();
-        verify(state, times(1)).discardState();
+        subtaskStateMock.verifyDiscard();
 
         // Abort subsumed
-        Mockito.reset(state);
+        subtaskStateMock.reset();
 
         pending = createPendingCheckpoint(props, executor);
         setTaskState(pending, state);
@@ -273,7 +270,7 @@ class PendingCheckpointTest {
         abort(pending, CheckpointFailureReason.CHECKPOINT_SUBSUMED);
         // execute asynchronous discard operation
         executor.runQueuedCommands();
-        verify(state, times(1)).discardState();
+        subtaskStateMock.verifyDiscard();
     }
 
     /**

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.util;
 
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.configuration.StateChangelogOptions;
@@ -118,6 +119,7 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
                     Duration.ofSeconds(0),
                     Duration.ofMillis(100),
                     Duration.ofSeconds(2));
+            randomize(conf, CheckpointingOptions.CLEANER_PARALLEL_MODE, true, false);
         }
 
         // randomize ITTests for enabling state change log


### PR DESCRIPTION
Flink 1.19 has made a change that will allow checkpoint fragments to be deleted in parallel, but is available in v1.19. This PR cherrypicks that change to be used in v1.17.